### PR TITLE
feat: add comment_options beneficiaries extension support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,51 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Create release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run tests
+        run: make test
+
+      - name: Generate changelog
+        id: changelog
+        run: |
+          PREV_TAG=$(git tag --sort=-version:refname | sed -n '2p')
+          if [ -z "$PREV_TAG" ]; then
+            CHANGELOG=$(git log --pretty=format:"- %s (%h)" HEAD)
+          else
+            CHANGELOG=$(git log --pretty=format:"- %s (%h)" "${PREV_TAG}..HEAD")
+          fi
+          {
+            echo "changelog<<EOF"
+            echo "$CHANGELOG"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          body: |
+            ## Changes
+
+            ${{ steps.changelog.outputs.changelog }}
+          generate_release_notes: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+gen_serializer_fixtures

--- a/cmd/gen_serializer_fixtures/README.md
+++ b/cmd/gen_serializer_fixtures/README.md
@@ -1,0 +1,99 @@
+# Serializer Fixtures Generator
+
+This tool generates JSON fixtures for cross-language serialization verification between Go SDK (steemutil) and JavaScript SDK (steem-js).
+
+## Purpose
+
+When implementing or modifying transaction serialization logic, it's critical to ensure that both Go and JavaScript SDKs produce identical binary output. This tool generates test fixtures that can be used by steem-js tests to verify serialization compatibility.
+
+## Usage
+
+```bash
+# Run the generator
+go run ./cmd/gen_serializer_fixtures/
+
+# Output files will be written to /tmp/steem-serializer-fixtures/
+ls /tmp/steem-serializer-fixtures/
+```
+
+## Output Format
+
+Each fixture is a JSON file with the following structure:
+
+```json
+{
+  "name": "transfer_basic",
+  "tx": {
+    "ref_block_num": 19297,
+    "ref_block_prefix": 1608085982,
+    "expiration": "2016-03-23T22:41:21",
+    "operations": [
+      ["transfer", {
+        "from": "alice",
+        "to": "bob",
+        "amount": "1.000 STEEM",
+        "memo": "hello"
+      }]
+    ],
+    "extensions": []
+  },
+  "expected_hex": "..."
+}
+```
+
+- `name`: Fixture identifier
+- `tx`: Transaction in JSON format (compatible with steem-js `serializeTransaction` input)
+- `expected_hex`: Expected hexadecimal output from Go SDK serialization
+
+## Verification Workflow
+
+1. **Generate fixtures** with this tool:
+   ```bash
+   go run ./cmd/gen_serializer_fixtures/
+   ```
+
+2. **Copy fixtures** to steem-js test directory
+
+3. **Run steem-js tests** that:
+   - Parse the `tx` JSON
+   - Serialize using steem-js serializer
+   - Compare output with `expected_hex`
+
+4. **If hex doesn't match**, there's a serialization discrepancy that needs investigation
+
+## Available Fixtures
+
+| Fixture Name | Operation Type | Description |
+|--------------|----------------|-------------|
+| `transfer_basic` | transfer | Basic token transfer |
+| `account_create_with_delegation_basic` | account_create_with_delegation | Account creation with delegation |
+| `withdraw_vesting_basic` | withdraw_vesting | Vesting withdrawal |
+| `limit_order_create2_basic` | limit_order_create2 | Limit order creation |
+| `escrow_transfer_basic` | escrow_transfer | Escrow transfer |
+| `claim_reward_balance_basic` | claim_reward_balance | Claim rewards |
+| `pow_basic` | pow | Proof of work |
+| `witness_update_basic` | witness_update | Witness update |
+| `custom_json_basic` | custom_json | Custom JSON operation |
+| `custom_binary_basic` | custom_binary | Custom binary operation |
+| `comment_options_beneficiaries` | comment_options | Comment options with single beneficiary |
+| `comment_options_beneficiaries_multiple` | comment_options | Comment options with multiple beneficiaries |
+
+## Adding New Fixtures
+
+To add a new fixture, edit `main.go` and append to the `fixtures` slice:
+
+```go
+fixtures = append(fixtures, makeTxFixture(
+    "your_fixture_name",
+    "operation_type",
+    &protocol.YourOperation{
+        // operation fields
+    },
+))
+```
+
+## Notes
+
+- All fixtures use fixed `ref_block_num`, `ref_block_prefix`, and `expiration` values for reproducibility
+- Beneficiaries in `comment_options` must be sorted alphabetically by account name (Steem protocol requirement)
+- Asset fields (Amount, Fee, etc.) are automatically encoded in binary format

--- a/cmd/gen_serializer_fixtures/main.go
+++ b/cmd/gen_serializer_fixtures/main.go
@@ -264,6 +264,45 @@ func main() {
 		},
 	))
 
+	// comment_options with beneficiaries
+	fixtures = append(fixtures, makeTxFixture(
+		"comment_options_beneficiaries",
+		"comment_options",
+		&protocol.CommentOptionsOperation{
+			Author:               "alice",
+			Permlink:             "test-post",
+			MaxAcceptedPayout:    "1000000.000 SBD",
+			PercentSteemDollars:  10000,
+			AllowVotes:           true,
+			AllowCurationRewards: true,
+			Extensions: protocol.CommentOptionsExtensions{
+				protocol.NewBeneficiariesExtension([]protocol.Beneficiary{
+					{Account: "bob", Weight: 3000},
+				}),
+			},
+		},
+	))
+
+	// comment_options with multiple beneficiaries (sorted alphabetically as required by Steem)
+	fixtures = append(fixtures, makeTxFixture(
+		"comment_options_beneficiaries_multiple",
+		"comment_options",
+		&protocol.CommentOptionsOperation{
+			Author:               "alice",
+			Permlink:             "test-post-multi",
+			MaxAcceptedPayout:    "1000000.000 SBD",
+			PercentSteemDollars:  10000,
+			AllowVotes:           true,
+			AllowCurationRewards: true,
+			Extensions: protocol.CommentOptionsExtensions{
+				protocol.NewBeneficiariesExtension([]protocol.Beneficiary{
+					{Account: "bob", Weight: 2000},
+					{Account: "charlie", Weight: 1000},
+				}),
+			},
+		},
+	))
+
 	for _, f := range fixtures {
 		writeFixture(outDir, f)
 		fmt.Fprintf(os.Stderr, "wrote fixture %s\n", f.Name)

--- a/cmd/gen_serializer_fixtures/main.go
+++ b/cmd/gen_serializer_fixtures/main.go
@@ -1,0 +1,272 @@
+package main
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/steemit/steemutil/encoder"
+	"github.com/steemit/steemutil/protocol"
+	"github.com/steemit/steemutil/transaction"
+)
+
+type Fixture struct {
+	Name        string                 `json:"name"`
+	Tx          map[string]interface{} `json:"tx"`
+	ExpectedHex string                 `json:"expected_hex"`
+}
+
+func mustTime(s string) *protocol.Time {
+	parsed, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		panic(err)
+	}
+	return &protocol.Time{Time: &parsed}
+}
+
+func makeTxFixture(name string, opName string, op protocol.Operation) Fixture {
+	// Use fixed header so JS side can construct identical tx objects.
+	refBlockNum := protocol.UInt16(19297)
+	refBlockPrefix := protocol.UInt32(1608085982)
+	expiration := mustTime("2016-03-23T22:41:21Z")
+
+	tx := &transaction.Transaction{
+		RefBlockNum:    refBlockNum,
+		RefBlockPrefix: refBlockPrefix,
+		Expiration:     expiration,
+		Operations:     protocol.Operations{op},
+		Extensions:     []interface{}{},
+	}
+
+	var buf bytes.Buffer
+	enc := encoder.NewEncoder(&buf)
+	if err := enc.Encode(tx); err != nil {
+		panic(fmt.Errorf("failed to encode tx for %s: %w", name, err))
+	}
+
+	expectedHex := hex.EncodeToString(buf.Bytes())
+
+	// Build JSON tx payload matching steem-js serializeTransaction input.
+	// operations must be [[opName, opData]] where opData uses JSON field names.
+	opJSON, err := json.Marshal(op)
+	if err != nil {
+		panic(fmt.Errorf("failed to marshal op %s to JSON: %w", name, err))
+	}
+	var opData map[string]interface{}
+	if err := json.Unmarshal(opJSON, &opData); err != nil {
+		panic(fmt.Errorf("failed to unmarshal op %s JSON: %w", name, err))
+	}
+
+	txJSON := map[string]interface{}{
+		"ref_block_num":    uint16(refBlockNum),
+		"ref_block_prefix": uint32(refBlockPrefix),
+		"expiration":       "2016-03-23T22:41:21", // without Z, matches steem-js tests
+		"operations": []interface{}{
+			[]interface{}{opName, opData},
+		},
+		"extensions": []interface{}{},
+	}
+
+	return Fixture{
+		Name:        name,
+		Tx:          txJSON,
+		ExpectedHex: expectedHex,
+	}
+}
+
+func writeFixture(dir string, f Fixture) {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		panic(fmt.Errorf("failed to create dir %s: %w", dir, err))
+	}
+	path := filepath.Join(dir, fmt.Sprintf("%s.json", f.Name))
+
+	data, err := json.MarshalIndent(f, "", "  ")
+	if err != nil {
+		panic(fmt.Errorf("failed to marshal fixture %s: %w", f.Name, err))
+	}
+
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		panic(fmt.Errorf("failed to write fixture %s: %w", path, err))
+	}
+}
+
+func main() {
+	outDir := "/tmp/steem-serializer-fixtures"
+
+	// Representative operations from each functional group.
+	var fixtures []Fixture
+
+	// transfer
+	fixtures = append(fixtures, makeTxFixture(
+		"transfer_basic",
+		"transfer",
+		&protocol.TransferOperation{
+			From:   "alice",
+			To:     "bob",
+			Amount: "1.000 STEEM",
+			Memo:   "hello",
+		},
+	))
+
+	// account_create_with_delegation
+	fixtures = append(fixtures, makeTxFixture(
+		"account_create_with_delegation_basic",
+		"account_create_with_delegation",
+		&protocol.AccountCreateWithDelegationOperation{
+			Fee:        "0.000 STEEM",
+			Delegation: "0.000000 VESTS",
+			Creator:    "initminer",
+			NewAccountName: "alice",
+			Owner: &protocol.Authority{
+				WeightThreshold: 1,
+				AccountAuths:    protocol.StringInt64Map{},
+				KeyAuths:        protocol.StringInt64Map{"STM8k1f8fvHxLrCTqMdRUJcK2rCE3y7SQBb8PremyadWvVWMeedZy": 1},
+			},
+			Active: &protocol.Authority{
+				WeightThreshold: 1,
+				AccountAuths:    protocol.StringInt64Map{},
+				KeyAuths:        protocol.StringInt64Map{"STM8k1f8fvHxLrCTqMdRUJcK2rCE3y7SQBb8PremyadWvVWMeedZy": 1},
+			},
+			Posting: &protocol.Authority{
+				WeightThreshold: 1,
+				AccountAuths:    protocol.StringInt64Map{},
+				KeyAuths:        protocol.StringInt64Map{"STM8k1f8fvHxLrCTqMdRUJcK2rCE3y7SQBb8PremyadWvVWMeedZy": 1},
+			},
+			MemoKey:      "STM6ppNVEFmvBW4jEkzxXnGKuKuwYjMUrhz2WX1kHeGSchGdWJEDQ",
+			JsonMetadata: "",
+			Extensions:   []interface{}{},
+		},
+	))
+
+	// withdraw_vesting
+	fixtures = append(fixtures, makeTxFixture(
+		"withdraw_vesting_basic",
+		"withdraw_vesting",
+		&protocol.WithdrawVestingOperation{
+			Account:       "alice",
+			VestingShares: "10.000000 VESTS",
+		},
+	))
+
+	// limit_order_create2
+	fixtures = append(fixtures, makeTxFixture(
+		"limit_order_create2_basic",
+		"limit_order_create2",
+		&protocol.LimitOrderCreate2Operation{
+			Owner:        "alice",
+			OrderID:      123,
+			AmountToSell: "1.000 STEEM",
+			ExchangeRate: struct {
+				Base  string `json:"base"`
+				Quote string `json:"quote"`
+			}{
+				Base:  "1.000 STEEM",
+				Quote: "1.000 SBD",
+			},
+			FillOrKill: false,
+			Expiration: mustTime("2016-03-24T16:05:00Z"),
+		},
+	))
+
+	// escrow_transfer
+	fixtures = append(fixtures, makeTxFixture(
+		"escrow_transfer_basic",
+		"escrow_transfer",
+		&protocol.EscrowTransferOperation{
+			From:        "alice",
+			To:          "bob",
+			SBDAmount:   "1.000 SBD",
+			SteemAmount: "0.000 STEEM",
+			EscrowID:    1,
+			Agent:       "carol",
+			Fee:         "0.001 STEEM",
+			JsonMeta:    "",
+			RatificationDeadline: mustTime("2016-03-24T16:10:00Z"),
+			EscrowExpiration:     mustTime("2016-03-25T16:10:00Z"),
+		},
+	))
+
+	// claim_reward_balance
+	fixtures = append(fixtures, makeTxFixture(
+		"claim_reward_balance_basic",
+		"claim_reward_balance",
+		&protocol.ClaimRewardBalanceOperation{
+			Account:     "alice",
+			RewardSteem: "1.000 STEEM",
+			RewardSBD:   "0.500 SBD",
+			RewardVests: "10.000000 VESTS",
+		},
+	))
+
+	// pow
+	nonce := protocol.UInt64(427)
+	fixtures = append(fixtures, makeTxFixture(
+		"pow_basic",
+		"pow",
+		&protocol.POWOperation{
+			WorkerAccount: "nxt4",
+			BlockID:       "0000044666219088eff80258e4d2c73523a5203c",
+			Nonce:         &nonce,
+			Work: &protocol.POW{
+				Worker:    "STM5gzvDurFRmVUUs38TDtTtGVAEz8TcWMt4xLVbxwP2PP8b9q7P4",
+				Input:     "8afebe79fb50fab989ca5a5bd8ebdbbbab838e8e8dc8bb6386889bf6c2344bc7",
+				Signature: "1f6dad80034431283996e4a4f95d5130423cffc6d18e7d7ecb89345fe1be7931320c634aa945124c622ca99ab52a3358def3118ca5d12bf3f54d82a539795b707a",
+				Work:      "002495e36694a3733737138bffaacc4cf425ca868b02214323f70f996934d2c5",
+			},
+			Props: &protocol.ChainProperties{
+				AccountCreationFee: "0.200 STEEM",
+				MaximumBlockSize:   131072,
+				SBDInterestRate:    1000,
+			},
+		},
+	))
+
+	// witness_update
+	fixtures = append(fixtures, makeTxFixture(
+		"witness_update_basic",
+		"witness_update",
+		&protocol.WitnessUpdateOperation{
+			Owner:           "initminer",
+			URL:             "https://example.com",
+			BlockSigningKey: "STM5gzvDurFRmVUUs38TDtTtGVAEz8TcWMt4xLVbxwP2PP8b9q7P4",
+			Props: &protocol.ChainProperties{
+				AccountCreationFee: "0.200 STEEM",
+				MaximumBlockSize:   65536,
+				SBDInterestRate:    1000,
+			},
+			Fee: "0.000 STEEM",
+		},
+	))
+
+	// custom_json
+	fixtures = append(fixtures, makeTxFixture(
+		"custom_json_basic",
+		"custom_json",
+		&protocol.CustomJSONOperation{
+			RequiredAuths:        []string{"alice"},
+			RequiredPostingAuths: []string{},
+			ID:                   "follow",
+			JSON:                 `{"foo":"bar"}`,
+		},
+	))
+
+	// custom_binary
+	fixtures = append(fixtures, makeTxFixture(
+		"custom_binary_basic",
+		"custom_binary",
+		&protocol.CustomBinaryOperation{
+			ID:        "test",
+			DataBytes: "01020304",
+		},
+	))
+
+	for _, f := range fixtures {
+		writeFixture(outDir, f)
+		fmt.Fprintf(os.Stderr, "wrote fixture %s\n", f.Name)
+	}
+}
+

--- a/encoder/encoder.go
+++ b/encoder/encoder.go
@@ -212,6 +212,12 @@ func (encoder *Encoder) encodeByReflection(v interface{}) error {
 		return errors.New("cannot encode nil value")
 	}
 
+	// Check for TransactionMarshaller BEFORE dereferencing pointers
+	// This is important for types like CommentOptionsExtension that implement MarshalTransaction
+	if marshaller, ok := v.(TransactionMarshaller); ok {
+		return marshaller.MarshalTransaction(encoder)
+	}
+
 	rv := reflect.ValueOf(v)
 	if rv.Kind() == reflect.Ptr {
 		if rv.IsNil() {
@@ -285,7 +291,8 @@ func (encoder *Encoder) encodeStruct(rv reflect.Value) error {
 				fieldName == "VestingShares" || fieldName == "SBDAmount" || fieldName == "SteemAmount" ||
 				fieldName == "RewardSteem" || fieldName == "RewardSBD" || fieldName == "RewardVests" ||
 				fieldName == "Fee" || fieldName == "Delegation" ||
-				fieldName == "AccountCreationFee" || fieldName == "Base" || fieldName == "Quote" {
+				fieldName == "AccountCreationFee" || fieldName == "Base" || fieldName == "Quote" ||
+				fieldName == "MaxAcceptedPayout" {
 				assetStr := field.String()
 				// Check if it looks like an asset string (contains space and has numeric part)
 				if strings.Contains(assetStr, " ") && len(strings.Split(assetStr, " ")) == 2 {

--- a/encoder/encoder.go
+++ b/encoder/encoder.go
@@ -283,7 +283,9 @@ func (encoder *Encoder) encodeStruct(rv reflect.Value) error {
 			fieldName := fieldType.Name
 			if fieldName == "Amount" || fieldName == "AmountToSell" || fieldName == "MinToReceive" ||
 				fieldName == "VestingShares" || fieldName == "SBDAmount" || fieldName == "SteemAmount" ||
-				fieldName == "RewardSteem" || fieldName == "RewardSBD" || fieldName == "RewardVests" {
+				fieldName == "RewardSteem" || fieldName == "RewardSBD" || fieldName == "RewardVests" ||
+				fieldName == "Fee" || fieldName == "Delegation" ||
+				fieldName == "AccountCreationFee" || fieldName == "Base" || fieldName == "Quote" {
 				assetStr := field.String()
 				// Check if it looks like an asset string (contains space and has numeric part)
 				if strings.Contains(assetStr, " ") && len(strings.Split(assetStr, " ")) == 2 {

--- a/protocol/operations.go
+++ b/protocol/operations.go
@@ -1,6 +1,7 @@
 package protocol
 
 import (
+	"encoding/hex"
 	"encoding/json"
 
 	"github.com/steemit/steemutil/encoder"
@@ -936,6 +937,21 @@ func (op *CancelTransferFromSavingsOperation) Data() any {
 type CustomBinaryOperation struct {
 	ID        string `json:"id"`
 	DataBytes string `json:"data"`
+}
+
+// MarshalTransaction encodes id as string, then data as length-prefixed raw bytes (DataBytes is hex string).
+func (op *CustomBinaryOperation) MarshalTransaction(encoderObj *encoder.Encoder) error {
+	if err := encoderObj.Encode(op.ID); err != nil {
+		return err
+	}
+	data, err := hex.DecodeString(op.DataBytes)
+	if err != nil {
+		return err
+	}
+	if err := encoderObj.EncodeUVarint(uint64(len(data))); err != nil {
+		return err
+	}
+	return encoderObj.WriteBytes(data)
 }
 
 func (op *CustomBinaryOperation) Type() OpType {

--- a/protocol/operations.go
+++ b/protocol/operations.go
@@ -538,13 +538,13 @@ func (op *DeleteCommentOperation) Data() any {
 //             (extensions) )
 
 type CommentOptionsOperation struct {
-	Author               string `json:"author"`
-	Permlink             string `json:"permlink"`
-	MaxAcceptedPayout    string `json:"max_accepted_payout"`
-	PercentSteemDollars  uint16 `json:"percent_steem_dollars"`
-	AllowVotes           bool   `json:"allow_votes"`
-	AllowCurationRewards bool   `json:"allow_curation_rewards"`
-	Extensions           []any  `json:"extensions"`
+	Author               string                     `json:"author"`
+	Permlink             string                     `json:"permlink"`
+	MaxAcceptedPayout    string                     `json:"max_accepted_payout"`
+	PercentSteemDollars  uint16                     `json:"percent_steem_dollars"`
+	AllowVotes           bool                       `json:"allow_votes"`
+	AllowCurationRewards bool                       `json:"allow_curation_rewards"`
+	Extensions           CommentOptionsExtensions `json:"extensions"`
 }
 
 func (op *CommentOptionsOperation) Type() OpType {
@@ -554,6 +554,67 @@ func (op *CommentOptionsOperation) Type() OpType {
 func (op *CommentOptionsOperation) Data() any {
 	return op
 }
+
+// Beneficiary represents beneficiary routing information.
+// Steem protocol requires beneficiaries to be sorted alphabetically by account.
+type Beneficiary struct {
+	Account string `json:"account"`
+	Weight  uint16 `json:"weight"`
+}
+
+// CommentPayoutBeneficiaries represents the beneficiaries extension for comment options.
+type CommentPayoutBeneficiaries struct {
+	Beneficiaries []Beneficiary `json:"beneficiaries"`
+}
+
+// CommentOptionsExtensionType defines the extension type tag.
+type CommentOptionsExtensionType uint8
+
+const (
+	// CommentOptionsExtensionBeneficiaries is the tag for beneficiaries extension (0).
+	CommentOptionsExtensionBeneficiaries CommentOptionsExtensionType = 0
+)
+
+// CommentOptionsExtension represents comment_options_extension (static_variant).
+// In Steem protocol: typedef static_variant<comment_payout_beneficiaries> comment_options_extension
+// Serialization format: varint(tag) + value
+type CommentOptionsExtension struct {
+	Tag   CommentOptionsExtensionType
+	Value interface{}
+}
+
+// MarshalTransaction implements TransactionMarshaller interface.
+// Encodes in Steem's static_variant format: varint(tag) + value
+func (e *CommentOptionsExtension) MarshalTransaction(enc *encoder.Encoder) error {
+	// 1. Encode tag as varint
+	if err := enc.EncodeUVarint(uint64(e.Tag)); err != nil {
+		return err
+	}
+	// 2. Encode value
+	return enc.Encode(e.Value)
+}
+
+// MarshalJSON implements json.Marshaler interface.
+// condenser_api's old_sv_from_variant expects array format: [tag, value]
+// See: libraries/plugins/apis/condenser_api/condenser_api_legacy_operations.cpp
+func (e *CommentOptionsExtension) MarshalJSON() ([]byte, error) {
+	// Serialize extension as [tag, value] format (array format)
+	return json.Marshal([]interface{}{uint8(e.Tag), e.Value})
+}
+
+// NewBeneficiariesExtension creates a beneficiaries extension.
+func NewBeneficiariesExtension(beneficiaries []Beneficiary) *CommentOptionsExtension {
+	return &CommentOptionsExtension{
+		Tag: CommentOptionsExtensionBeneficiaries,
+		Value: &CommentPayoutBeneficiaries{
+			Beneficiaries: beneficiaries,
+		},
+	}
+}
+
+// CommentOptionsExtensions is the extension list for comment_options.
+// Corresponds to Steem's flat_set<comment_options_extension>
+type CommentOptionsExtensions []*CommentOptionsExtension
 
 type Authority struct {
 	AccountAuths    StringInt64Map `json:"account_auths"`

--- a/protocol/operations_test.go
+++ b/protocol/operations_test.go
@@ -109,7 +109,7 @@ func TestCommentOptionsOperation_Type(t *testing.T) {
 		PercentSteemDollars:  50,
 		AllowVotes:           true,
 		AllowCurationRewards: true,
-		Extensions:           []interface{}{},
+		Extensions:           CommentOptionsExtensions{},
 	}
 
 	if op.Type() != TypeCommentOptions {


### PR DESCRIPTION
## Summary

- Add support for `comment_options` operation with beneficiaries extension
- Add `Beneficiary`, `CommentPayoutBeneficiaries`, `CommentOptionsExtension` types for proper serialization
- Fix `MaxAcceptedPayout` asset encoding in encoder (was being serialized as string instead of asset)
- Update test to use correct `CommentOptionsExtensions` type

## Changes

### encoder/encoder.go
- Add `MaxAcceptedPayout` to asset field list for proper binary serialization

### protocol/operations.go
- Add `Beneficiary` struct for beneficiary routing info
- Add `CommentPayoutBeneficiaries` struct for beneficiaries extension
- Add `CommentOptionsExtension` type with `MarshalTransaction` and `MarshalJSON` methods
- Add `CommentOptionsExtensions` type alias
- Add `NewBeneficiariesExtension` helper function

### protocol/operations_test.go
- Fix `Extensions` field type from `[]interface{}` to `CommentOptionsExtensions`

## Test Plan

- [x] Unit tests pass (`go test ./...`)
- [x] Tested with live Steem blockchain - post with beneficiaries succeeded (TX: `200818f36a81c98b0aaf56aa2f6d7639e4ba242f`)