### PR TITLE
feat: auto-sort beneficiaries alphabetically

### DIFF
--- a/protocol/operations.go
+++ b/protocol/operations.go
@@ -3,6 +3,7 @@ package protocol
 import (
 	"encoding/hex"
 	"encoding/json"
+	"sort"
 
 	"github.com/steemit/steemutil/encoder"
 )
@@ -603,7 +604,13 @@ func (e *CommentOptionsExtension) MarshalJSON() ([]byte, error) {
 }
 
 // NewBeneficiariesExtension creates a beneficiaries extension.
+// Beneficiaries are automatically sorted alphabetically by account name
+// as required by the Steem protocol.
 func NewBeneficiariesExtension(beneficiaries []Beneficiary) *CommentOptionsExtension {
+	// Auto-sort beneficiaries alphabetically by account (Steem protocol requirement)
+	sort.Slice(beneficiaries, func(i, j int) bool {
+		return beneficiaries[i].Account < beneficiaries[j].Account
+	})
 	return &CommentOptionsExtension{
 		Tag: CommentOptionsExtensionBeneficiaries,
 		Value: &CommentPayoutBeneficiaries{


### PR DESCRIPTION
## Summary
- Auto-sort beneficiaries alphabetically by account name in `NewBeneficiariesExtension`
- Steem protocol requires beneficiaries to be sorted, this ensures compliance automatically

## Changes
- Added `sort` import to `protocol/operations.go`
- Modified `NewBeneficiariesExtension` to sort beneficiaries before creating the extension

## Test plan
- [x] All existing tests pass
- [x] Manual testing with steemgosdk integration