### PR TITLE
fix: unmarshal comment_options extensions from condenser API

### DIFF
--- a/protocol/operations.go
+++ b/protocol/operations.go
@@ -3,6 +3,7 @@ package protocol
 import (
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"sort"
 
 	"github.com/steemit/steemutil/encoder"
@@ -601,6 +602,36 @@ func (e *CommentOptionsExtension) MarshalTransaction(enc *encoder.Encoder) error
 func (e *CommentOptionsExtension) MarshalJSON() ([]byte, error) {
 	// Serialize extension as [tag, value] format (array format)
 	return json.Marshal([]interface{}{uint8(e.Tag), e.Value})
+}
+
+// UnmarshalJSON implements json.Unmarshaler interface.
+// condenser_api returns each extension as [tag, value] (static_variant).
+func (e *CommentOptionsExtension) UnmarshalJSON(data []byte) error {
+	var tuple []json.RawMessage
+	if err := json.Unmarshal(data, &tuple); err != nil {
+		return err
+	}
+	if len(tuple) != 2 {
+		return fmt.Errorf("comment_options_extension: expected [tag, value], got %d elements", len(tuple))
+	}
+
+	var tag uint8
+	if err := json.Unmarshal(tuple[0], &tag); err != nil {
+		return err
+	}
+	e.Tag = CommentOptionsExtensionType(tag)
+
+	switch e.Tag {
+	case CommentOptionsExtensionBeneficiaries:
+		var beneficiaries CommentPayoutBeneficiaries
+		if err := json.Unmarshal(tuple[1], &beneficiaries); err != nil {
+			return err
+		}
+		e.Value = &beneficiaries
+	default:
+		e.Value = tuple[1]
+	}
+	return nil
 }
 
 // NewBeneficiariesExtension creates a beneficiaries extension.

--- a/protocol/operations_test.go
+++ b/protocol/operations_test.go
@@ -117,6 +117,43 @@ func TestCommentOptionsOperation_Type(t *testing.T) {
 	}
 }
 
+func TestCommentOptionsExtension_UnmarshalJSON(t *testing.T) {
+	raw := `[0, {"beneficiaries": [{"account": "san.marco", "weight": 10000}]}]`
+	var ext CommentOptionsExtension
+	if err := json.Unmarshal([]byte(raw), &ext); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if ext.Tag != CommentOptionsExtensionBeneficiaries {
+		t.Fatalf("unexpected tag %d", ext.Tag)
+	}
+	b, ok := ext.Value.(*CommentPayoutBeneficiaries)
+	if !ok {
+		t.Fatalf("expected *CommentPayoutBeneficiaries, got %T", ext.Value)
+	}
+	if len(b.Beneficiaries) != 1 || b.Beneficiaries[0].Account != "san.marco" {
+		t.Fatalf("unexpected beneficiaries: %+v", b.Beneficiaries)
+	}
+}
+
+func TestCommentOptionsOperation_UnmarshalJSON_withExtensions(t *testing.T) {
+	raw := `{
+		"allow_curation_rewards": true,
+		"allow_votes": true,
+		"author": "zimmerfield",
+		"extensions": [[0, {"beneficiaries": [{"account": "san.marco", "weight": 10000}]}]],
+		"max_accepted_payout": "1000000.000 SBD",
+		"percent_steem_dollars": 10000,
+		"permlink": "re-re-gauravchugh-life-redefined-20170818t104710636z-20220213t003946z"
+	}`
+	var op CommentOptionsOperation
+	if err := json.Unmarshal([]byte(raw), &op); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if len(op.Extensions) != 1 {
+		t.Fatalf("expected 1 extension, got %d", len(op.Extensions))
+	}
+}
+
 func TestCustomJSONOperation_Type(t *testing.T) {
 	op := &CustomJSONOperation{
 		RequiredAuths:        []string{},


### PR DESCRIPTION
## Summary
- Add `CommentOptionsExtension.UnmarshalJSON` for condenser_api `[tag, value]` static_variant tuples
- Add tests for extension parsing and full `comment_options` operation JSON

## Motivation
`GetOpsInBlock` fails on blocks with beneficiary extensions (e.g. block 61570519):
`cannot unmarshal array into Go struct field protocol.CommentOptionsOperation.extensions`

## Test plan
- [x] `go test ./protocol/ -run CommentOptions`