### PR TITLE
fix: encode public_key_type fields as 33-byte binary blobs

### DIFF
--- a/encoder/encoder.go
+++ b/encoder/encoder.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	"github.com/steemit/steemutil/wif"
 )
 
 type TransactionMarshaller interface {
@@ -318,6 +319,17 @@ func (encoder *Encoder) encodeStruct(rv reflect.Value) error {
 			}
 		}
 
+		// Check if this is a public_key_type field (tagged steem:"pubkey").
+		// In Steem's binary format, public keys are serialized as fixed
+		// 33-byte blobs (1 byte format + 32 bytes key data), not as
+		// varint-prefixed strings like the Go string fields they inhabit.
+		if field.Kind() == reflect.String && fieldType.Tag.Get("steem") == "pubkey" {
+			if err := encoder.encodePubKey(field.String()); err != nil {
+				return errors.Wrapf(err, "failed to encode public key field %s", fieldType.Name)
+			}
+			continue
+		}
+
 		// Recursively encode the field value
 		if err := encoder.encodeByReflection(fieldValue); err != nil {
 			return errors.Wrapf(err, "failed to encode field %s", fieldType.Name)
@@ -325,6 +337,17 @@ func (encoder *Encoder) encodeStruct(rv reflect.Value) error {
 	}
 
 	return nil
+}
+
+// encodePubKey parses a STM... public key string and encodes it as 33 bytes
+// (1 byte format + 32 bytes key data), matching Steem's public_key_type
+// binary serialization.
+func (encoder *Encoder) encodePubKey(stmKey string) error {
+	pubKey := &wif.PublicKey{}
+	if err := pubKey.FromStr(stmKey); err != nil {
+		return errors.Wrapf(err, "failed to parse public key: %s", stmKey)
+	}
+	return encoder.WriteBytes(pubKey.ToByte())
 }
 
 // encodeSlice encodes a slice by first encoding its length, then each element.

--- a/protocol/operations.go
+++ b/protocol/operations.go
@@ -245,7 +245,7 @@ type AccountCreateOperation struct {
 	Owner          *Authority `json:"owner"`
 	Active         *Authority `json:"active"`
 	Posting        *Authority `json:"posting"`
-	MemoKey        string     `json:"memo_key"`
+	MemoKey        string     `json:"memo_key" steem:"pubkey"`
 	JsonMetadata   string     `json:"json_metadata"`
 }
 
@@ -270,7 +270,7 @@ type AccountUpdateOperation struct {
 	Owner        *Authority `json:"owner" steem:"optional"`
 	Active       *Authority `json:"active" steem:"optional"`
 	Posting      *Authority `json:"posting" steem:"optional"`
-	MemoKey      string     `json:"memo_key"`
+	MemoKey      string     `json:"memo_key" steem:"pubkey"`
 	JsonMetadata string     `json:"json_metadata"`
 }
 
@@ -670,7 +670,7 @@ type Authority struct {
 type WitnessUpdateOperation struct {
 	Owner           string           `json:"owner"`
 	URL             string           `json:"url"`
-	BlockSigningKey string           `json:"block_signing_key"`
+	BlockSigningKey string           `json:"block_signing_key" steem:"pubkey"`
 	Props           *ChainProperties `json:"props"`
 	Fee             string           `json:"fee"`
 }

--- a/protocol/operations.go
+++ b/protocol/operations.go
@@ -767,7 +767,7 @@ type CreateClaimedAccountOperation struct {
 	Owner          *Authority `json:"owner"`
 	Active         *Authority `json:"active"`
 	Posting        *Authority `json:"posting"`
-	MemoKey        string     `json:"memo_key"`
+	MemoKey        string     `json:"memo_key" steem:"pubkey"`
 	JsonMetadata   string     `json:"json_metadata"`
 	Extensions     []any      `json:"extensions"`
 }
@@ -1176,7 +1176,7 @@ type AccountCreateWithDelegationOperation struct {
 	Owner          *Authority `json:"owner"`
 	Active         *Authority `json:"active"`
 	Posting        *Authority `json:"posting"`
-	MemoKey        string     `json:"memo_key"`
+	MemoKey        string     `json:"memo_key" steem:"pubkey"`
 	JsonMetadata   string     `json:"json_metadata"`
 	Extensions     []any      `json:"extensions"`
 }
@@ -1223,7 +1223,7 @@ type AccountUpdate2Operation struct {
 	Owner               *Authority `json:"owner" steem:"optional"`
 	Active              *Authority `json:"active" steem:"optional"`
 	Posting             *Authority `json:"posting" steem:"optional"`
-	MemoKey             string     `json:"memo_key"`
+	MemoKey             string     `json:"memo_key" steem:"pubkey"`
 	JsonMetadata        string     `json:"json_metadata"`
 	PostingJsonMetadata string     `json:"posting_json_metadata"`
 	Extensions          []any      `json:"extensions"`

--- a/protocol/pubkey_serialization_test.go
+++ b/protocol/pubkey_serialization_test.go
@@ -1,0 +1,138 @@
+package protocol
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+
+	"github.com/steemit/steemutil/encoder"
+)
+
+// PublicKey used across all tests:
+//   STM8m5UgaFAAYQRuaNejYdS8FVLVp9Ss3K1qAVk5de6F8s3HnVbvA
+//   Binary (33 bytes): 03fdf4907810a9f5d9462a1ae09feee5ab205d32798b0ffcc379442021f84c5bbf
+const testPubKey = "STM8m5UgaFAAYQRuaNejYdS8FVLVp9Ss3K1qAVk5de6F8s3HnVbvA"
+
+func encodeOp(t *testing.T, op interface{}) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	enc := encoder.NewEncoder(&buf)
+	if err := enc.Encode(op); err != nil {
+		t.Fatalf("Encode failed: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func assertHex(t *testing.T, name string, got []byte, expectedHex string) {
+	t.Helper()
+	gotHex := hex.EncodeToString(got)
+	if gotHex != expectedHex {
+		t.Errorf("%s hex mismatch:\n  expected (%d bytes): %s\n  got      (%d bytes): %s",
+			name, len(expectedHex)/2, expectedHex, len(got)/2, gotHex)
+	}
+}
+
+// TestWitnessUpdateSerialization verifies that block_signing_key is encoded
+// as a 33-byte public_key_type binary, NOT a varint-prefixed string.
+func TestWitnessUpdateSerialization(t *testing.T) {
+	op := &WitnessUpdateOperation{
+		Owner:           "owner",
+		URL:             "https://example.com",
+		BlockSigningKey: testPubKey,
+		Props: &ChainProperties{
+			AccountCreationFee: "0.100 STEEM",
+			MaximumBlockSize:   131072,
+			SBDInterestRate:    1000,
+		},
+		Fee: "0.000 STEEM",
+	}
+	// op_type(0b) + owner + url + 33-byte pubkey + props(3 assets) + fee asset
+	assertHex(t, "WitnessUpdate", encodeOp(t, op),
+		"0b056f776e65721368747470733a2f2f6578616d706c652e636f6d03fdf4907810a9f5d9462a1ae09feee5ab205d32798b0ffcc379442021f84c5bbf640000000000000003535445454d000000000200e803000000000000000003535445454d0000")
+}
+
+// TestAccountCreateSerialization verifies memo_key is encoded as 33-byte pubkey
+// and the plain (non-optional) authority pointers are serialized without presence bytes.
+func TestAccountCreateSerialization(t *testing.T) {
+	op := &AccountCreateOperation{
+		Fee:            "0.000 STEEM",
+		Creator:        "creator",
+		NewAccountName: "newaccount",
+		Owner:          &Authority{WeightThreshold: 1},
+		Active:         &Authority{WeightThreshold: 1},
+		Posting:        &Authority{WeightThreshold: 1},
+		MemoKey:        testPubKey,
+		JsonMetadata:   "{}",
+	}
+	assertHex(t, "AccountCreate", encodeOp(t, op),
+		"09000000000000000003535445454d00000763726561746f720a6e65776163636f756e7400000100000000000100000000000100000003fdf4907810a9f5d9462a1ae09feee5ab205d32798b0ffcc379442021f84c5bbf027b7d")
+}
+
+// TestAccountUpdateSerialization verifies optional authority fields (nil → 0x00)
+// alongside pubkey encoding for memo_key.
+func TestAccountUpdateSerialization(t *testing.T) {
+	op := &AccountUpdateOperation{
+		Account:      "account",
+		Owner:        nil, // optional → 0x00
+		Active:       nil, // optional → 0x00
+		Posting:      nil, // optional → 0x00
+		MemoKey:      testPubKey,
+		JsonMetadata: "",
+	}
+	// op_type(0a) + account + 3×0x00 (optional nil) + 33-byte pubkey + empty metadata + (no extensions field)
+	assertHex(t, "AccountUpdate", encodeOp(t, op),
+		"0a076163636f756e7400000003fdf4907810a9f5d9462a1ae09feee5ab205d32798b0ffcc379442021f84c5bbf00")
+}
+
+// TestAccountUpdate2Serialization verifies memo_key pubkey encoding with
+// optional authorities and extensions field.
+func TestAccountUpdate2Serialization(t *testing.T) {
+	op := &AccountUpdate2Operation{
+		Account:             "account",
+		Owner:               nil,
+		Active:              nil,
+		Posting:             nil,
+		MemoKey:             testPubKey,
+		JsonMetadata:        "",
+		PostingJsonMetadata: "",
+		Extensions:          []interface{}{},
+	}
+	assertHex(t, "AccountUpdate2", encodeOp(t, op),
+		"2b076163636f756e7400000003fdf4907810a9f5d9462a1ae09feee5ab205d32798b0ffcc379442021f84c5bbf000000")
+}
+
+// TestCreateClaimedAccountSerialization verifies memo_key pubkey encoding
+// with plain authorities and extensions.
+func TestCreateClaimedAccountSerialization(t *testing.T) {
+	op := &CreateClaimedAccountOperation{
+		Creator:        "creator",
+		NewAccountName: "newaccount",
+		Owner:          &Authority{WeightThreshold: 1},
+		Active:         &Authority{WeightThreshold: 1},
+		Posting:        &Authority{WeightThreshold: 1},
+		MemoKey:        testPubKey,
+		JsonMetadata:   "{}",
+		Extensions:     []interface{}{},
+	}
+	assertHex(t, "CreateClaimedAccount", encodeOp(t, op),
+		"170763726561746f720a6e65776163636f756e7400000100000000000100000000000100000003fdf4907810a9f5d9462a1ae09feee5ab205d32798b0ffcc379442021f84c5bbf027b7d00")
+}
+
+// TestAccountCreateWithDelegationSerialization verifies memo_key pubkey encoding
+// with delegation asset and extensions.
+func TestAccountCreateWithDelegationSerialization(t *testing.T) {
+	op := &AccountCreateWithDelegationOperation{
+		Fee:            "0.000 STEEM",
+		Delegation:     "1.000000 VESTS",
+		Creator:        "creator",
+		NewAccountName: "newaccount",
+		Owner:          &Authority{WeightThreshold: 1},
+		Active:         &Authority{WeightThreshold: 1},
+		Posting:        &Authority{WeightThreshold: 1},
+		MemoKey:        testPubKey,
+		JsonMetadata:   "{}",
+		Extensions:     []interface{}{},
+	}
+	assertHex(t, "AccountCreateWithDelegation", encodeOp(t, op),
+		"29000000000000000003535445454d000040420f000000000006564553545300000763726561746f720a6e65776163636f756e7400000100000000000100000000000100000003fdf4907810a9f5d9462a1ae09feee5ab205d32798b0ffcc379442021f84c5bbf027b7d00")
+}

--- a/transaction/witness_update_serialization_test.go
+++ b/transaction/witness_update_serialization_test.go
@@ -43,7 +43,7 @@ func TestWitnessUpdateGoldenHex(t *testing.T) {
 		t.Fatalf("Serialize failed: %v", err)
 	}
 
-	// Expected golden hex (131 bytes). Breakdown for reference:
+	// Expected golden hex (110 bytes). Breakdown for reference:
 	//   ec48            ref_block_num (18668 LE)
 	//   f00f8b91        ref_block_prefix (2441809904 LE)
 	//   0924b6a0        expiration (unix 1783337488 LE)
@@ -51,16 +51,16 @@ func TestWitnessUpdateGoldenHex(t *testing.T) {
 	//   0b              op_type (11 = witness_update)
 	//   06657479303031  owner "ety001" (varint-len 6)
 	//   1268...66616e73 url "https://steem.fans" (varint-len 18)
-	//   3553...4e716d   block_signing_key (varint-len 53)
+	//   03 66f...9efab1 block_signing_key (33-byte public_key_type binary)
 	//   b80b...000003   props.account_creation_fee (asset: uint64 3000, prec 3, "STEEM\0\0")
 	//   00010000        props.maximum_block_size (65536 LE)
 	//   0000            props.sbd_interest_rate (0 LE)
 	//   0000...0003     fee (asset: uint64 0, prec 3, "STEEM\0\0")
 	//   00              extensions count (0)
 	//
-	// CRITICAL: the byte after block_signing_key is 0xb8 (first byte of the
-	// asset amount), NOT 0x01. The old encoder inserted an erroneous 0x01 here.
-	const expectedHex = "ec48f00f8b9110924b6a010b066574793030311268747470733a2f2f737465656d2e66616e733553544d37634b6b7942437854526b64786f47535035797061674e656156596552376f576342734e664b75725867356a6e41744e716db80b00000000000003535445454d0000000001000000000000000000000003535445454d000000"
+	// CRITICAL: public_key_type fields (like block_signing_key) must serialize
+	// as fixed 33-byte blobs, NOT as varint-prefixed strings.
+	const expectedHex = "ec48f00f8b9110924b6a010b066574793030311268747470733a2f2f737465656d2e66616e73036661f9197bb27be62d4edd732d652225e051a8a79b1cd84cdbbc8bd4ab9efab1b80b00000000000003535445454d0000000001000000000000000000000003535445454d000000"
 
 	got := hex.EncodeToString(serialized)
 	if got != expectedHex {


### PR DESCRIPTION
## Problem

`public_key_type` fields (like `block_signing_key` in `witness_update`,
`memo_key` in `account_create`/`account_update`) were serialized as
varint-prefixed strings by the reflection encoder. In Steem's C++ binary
format, `public_key_type` is a fixed 33-byte blob (1 byte format + 32 bytes
key data), not a variable-length string.

This caused a digest mismatch on every transaction involving public keys:
the SDK computed the digest using a 54-byte varint-string represe ntation,
while steemd expected a 33-byte binary format.

## Fix

- Add `steem:"pubkey"` struct tag for `public_key_type` string fields
- Add `encodePubKey()` to the encoder: parses `STM...` → `wif.PublicKey`
  and writes the 33-byte compressed binary
- Tag `BlockSigningKey` in `WitnessUpdateOperation`, and all `MemoKey`
  fields in `AccountCreate`, `AccountUpdate`, `CreateClaimedAccount`,
  `AccountUpdate2`, `AccountCreateWithDelegation` operations
- Update golden hex in `TestWitnessUpdateGoldenHex` (131 → 110 bytes)

## Verification

```
$ make test   # all green
```

Tested with a live witness signing key update on Steem mainnet —
transaction `a840f7c70d3549ac53fcd83ca5740f2092364b03` accepted at
block 107590219.