### PR TITLE
fix(rpc): Validate accepts object params, not just arrays

### DIFF
--- a/rpc/auth.go
+++ b/rpc/auth.go
@@ -111,7 +111,14 @@ func Sign(request *RpcRequest, account string, privateKeys []string) (*SignedReq
 
 // Validate validates a signed JSON-RPC request.
 // The verifyFunc should verify that the signatures are valid for the given account.
-func Validate(request *SignedRequest, verifyFunc func(message []byte, signatures []string, account string) error) ([]interface{}, error) {
+//
+// The decoded params are returned as interface{} (not []interface{}) to match
+// the shape-agnostic semantics of the JS reference (@steemit/rpc-auth validate),
+// which returns JSON.parse(jsonString). Signed params can be a JSON object,
+// array, or scalar — conveyor and koa-jsonrpc clients sign object params
+// (e.g. {"account":"foo"}), so constraining to []interface{} would reject
+// every real-world authenticated request.
+func Validate(request *SignedRequest, verifyFunc func(message []byte, signatures []string, account string) error) (interface{}, error) {
 	if request.JsonRpc != "2.0" || request.Method == "" {
 		return nil, errors.New("invalid JSON RPC request")
 	}
@@ -122,8 +129,9 @@ func Validate(request *SignedRequest, verifyFunc func(message []byte, signatures
 		return nil, errors.New("missing account")
 	}
 
-	// Decode and validate params
-	var params []interface{}
+	// Decode and validate params. The target is interface{} so that any valid
+	// JSON shape (object, array, scalar) is accepted, matching JSON.parse in JS.
+	var params interface{}
 	paramsJSON, err := base64.StdEncoding.DecodeString(signed.Params)
 	if err != nil {
 		return nil, errors.Wrap(err, "invalid encoded params")

--- a/rpc/auth_test.go
+++ b/rpc/auth_test.go
@@ -1,11 +1,15 @@
 package rpc
 
 import (
+	"crypto/rand"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"testing"
 	"time"
+
+	"github.com/steemit/steemutil/wif"
 )
 
 // Test constants
@@ -113,14 +117,21 @@ func TestValidate(t *testing.T) {
 		t.Fatalf("Validate failed: %v", err)
 	}
 
-	// Verify that we got back the original params
-	if len(params) != len(testParams) {
-		t.Errorf("Expected %d params, got %d", len(testParams), len(params))
+	// Validate now returns interface{} (shape-agnostic, matching JS JSON.parse).
+	// The original testParams is []interface{}{[]string{"testuser"}}, so the
+	// decoded params should be a []interface{} with one element.
+	arr, ok := params.([]interface{})
+	if !ok {
+		t.Fatalf("Expected params to be []interface{}, got %T", params)
+	}
+
+	if len(arr) != len(testParams) {
+		t.Errorf("Expected %d params, got %d", len(testParams), len(arr))
 	}
 
 	// Compare the first param (should be a slice of strings)
 	originalParam := testParams[0].([]string)
-	recoveredParam := params[0].([]interface{})
+	recoveredParam := arr[0].([]interface{})
 
 	if len(recoveredParam) != len(originalParam) {
 		t.Errorf("Expected param length %d, got %d", len(originalParam), len(recoveredParam))
@@ -128,6 +139,63 @@ func TestValidate(t *testing.T) {
 
 	if recoveredParam[0].(string) != originalParam[0] {
 		t.Errorf("Expected param value '%s', got '%s'", originalParam[0], recoveredParam[0])
+	}
+}
+
+// TestValidate_ObjectParams is the regression test for the []interface{} bug.
+// Signed params in real-world conveyor / koa-jsonrpc clients are JSON objects
+// (e.g. {"account":"foo"}), not arrays. The old []interface{} decode target
+// would reject objects with "failed to unmarshal params".
+func TestValidate_ObjectParams(t *testing.T) {
+	// Build a signed request with object params (as a JSON string, since
+	// RpcRequest.Params is []interface{} — but Sign marshals whatever it gets).
+	// We construct the SignedRequest manually to use an object payload.
+	objParams := map[string]interface{}{
+		"account": "foo",
+		"meta":    map[string]interface{}{"k": "v"},
+	}
+	paramsJSON, _ := json.Marshal(objParams)
+	paramsB64 := base64.StdEncoding.EncodeToString(paramsJSON)
+	nonceBytes := make([]byte, 8)
+	rand.Read(nonceBytes)
+	timestamp := time.Now().UTC().Format(time.RFC3339Nano)
+
+	message := hashMessage(timestamp, testAccount, testMethod, paramsB64, nonceBytes)
+
+	privKey := &wif.PrivateKey{}
+	if err := privKey.FromWif(testPrivateKey); err != nil {
+		t.Fatalf("failed to parse private key: %v", err)
+	}
+	sig, err := privKey.SignSha256(message)
+	if err != nil {
+		t.Fatalf("failed to sign: %v", err)
+	}
+
+	signedRequest := &SignedRequest{
+		JsonRpc: "2.0",
+		Method:  testMethod,
+		ID:      1,
+	}
+	signedRequest.Params.Signed = SignedParams{
+		Account:    testAccount,
+		Nonce:      hex.EncodeToString(nonceBytes),
+		Params:     paramsB64,
+		Signatures: []string{hex.EncodeToString(sig)},
+		Timestamp:  timestamp,
+	}
+
+	params, err := Validate(signedRequest, DefaultVerifyFunc)
+	if err != nil {
+		t.Fatalf("Validate with object params failed: %v", err)
+	}
+
+	// The returned params should be a map (JSON object), not an array.
+	obj, ok := params.(map[string]interface{})
+	if !ok {
+		t.Fatalf("Expected params to be map[string]interface{}, got %T", params)
+	}
+	if obj["account"] != "foo" {
+		t.Errorf("Expected account 'foo', got %v", obj["account"])
 	}
 }
 

--- a/rpc/verify_test.go
+++ b/rpc/verify_test.go
@@ -254,8 +254,14 @@ func TestValidate_WithVerifySignedRpc(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Validate with VerifySignedRpc failed: %v", err)
 	}
-	if len(params) != 1 {
-		t.Errorf("expected 1 param, got %d", len(params))
+	// Validate returns interface{} (shape-agnostic); the signed params were an
+	// array, so type-assert before checking length.
+	arr, ok := params.([]interface{})
+	if !ok {
+		t.Fatalf("expected params to be []interface{}, got %T", params)
+	}
+	if len(arr) != 1 {
+		t.Errorf("expected 1 param, got %d", len(arr))
 	}
 }
 


### PR DESCRIPTION
## Problem

`rpc.Validate` decoded the signed params into `[]interface{}`, which rejects JSON objects. Real-world conveyor / `@steemit/koa-jsonrpc` clients sign **object** params (e.g. `{"account":"foo"}`), so every authenticated request fails with `"failed to unmarshal params"`.

## Root cause

The `[]interface{}` type was copied from `RpcRequest.Params` in the first commit and never revisited. The JS reference (`@steemit/rpc-auth validate`) returns `JSON.parse(jsonString)`, which is **shape-agnostic** (accepts objects, arrays, scalars — any valid JSON).

Evidence that this was not a deliberate design:
- No commit message or code comment argues for an "arrays only" convention
- The JS reference's own server tests (`koa-jsonrpc/test/auth.ts`) sign with object params exclusively
- Every Go test only used array params, so the bug was invisible to the suite

## Fix

Changed the decode target and return type from `[]interface{}` to `interface{}`, matching JS `JSON.parse` semantics.

**Breaking change** for callers of `rpc.Validate`: return type changes from `[]interface{}` to `interface{}`. The only known production caller is `steemgosdk`'s `API.VerifySignedRequest`, which will be updated in a follow-up PR once this is tagged.

## Tests

- `TestValidate` and `TestValidate_WithVerifySignedRpc` updated to type-assert the returned `interface{}` before indexing (they previously assumed `[]interface{}`)
- New `TestValidate_ObjectParams` regression test: signs and validates object params — this fails on the old code with `"failed to unmarshal params"`, passes after the fix

## Verification

- `go build ./...` ✅
- `go vet ./...` ✅  
- `go test ./rpc/ -v` ✅ (all pass including the new regression test)