### PR TITLE
fix(transaction): make Verify recover-and-compare, fail-closed

### DIFF
--- a/transaction/signed_transaction.go
+++ b/transaction/signed_transaction.go
@@ -14,6 +14,12 @@ import (
 	"github.com/pkg/errors"
 )
 
+// errInvalidSignature is returned by Verify when a signature fails any
+// non-parse validation check (wrong key, tampered digest, bad format).
+// Recoverable parse failures are surfaced as errors too; callers that only
+// care about the boolean result can ignore the error.
+var errInvalidSignature = errors.New("invalid transaction signature")
+
 type SignedTransaction struct {
 	*Transaction
 }
@@ -93,6 +99,17 @@ func (tx *SignedTransaction) Sign(privKeys []*wif.PrivateKey, chain *Chain) erro
 	return nil
 }
 
+// Verify validates every signature on the transaction against pubKeys by
+// recovering each signer's public key from the compact (recoverable)
+// signature and comparing it to the expected key.
+//
+// Signatures are produced by Sign via ecdsa.SignCompact, i.e. they are
+// 65-byte compact signatures whose first byte encodes the recovery id
+// (range 31..34 for compressed keys). Verification therefore must use
+// recover-and-compare (ecdsa.RecoverCompact), not DER parsing.
+//
+// Verify is fail-closed: an empty signature slice, a count mismatch, a
+// malformed signature, or any key mismatch yields (false, <non-nil error>).
 func (tx *SignedTransaction) Verify(pubKeys []*wif.PublicKey, chain *Chain) (bool, error) {
 	// Compute digest
 	digest, err := tx.Digest(chain)
@@ -100,16 +117,41 @@ func (tx *SignedTransaction) Verify(pubKeys []*wif.PublicKey, chain *Chain) (boo
 		return false, err
 	}
 
-	// Parse signatures
-	sigs := make([][]byte, 0, len(tx.Signatures))
-	for i, sig := range sigs {
-		tmpSig, err := ecdsa.ParseSignature(sig)
+	// Fail-closed: no signatures means nothing to verify.
+	if len(tx.Signatures) == 0 {
+		return false, errors.Wrap(errInvalidSignature, "no signatures to verify")
+	}
+	// Each signature corresponds positionally to one pubKey.
+	if len(pubKeys) < len(tx.Signatures) {
+		return false, errors.Wrapf(errInvalidSignature, "need %d pubkeys, got %d", len(tx.Signatures), len(pubKeys))
+	}
+
+	for i, sigHex := range tx.Signatures {
+		sig, err := hex.DecodeString(sigHex)
 		if err != nil {
-			return false, err
+			return false, errors.Wrapf(errInvalidSignature, "signature %d is not valid hex", i)
 		}
-		verified := tmpSig.Verify(digest, pubKeys[i].Raw)
-		if !verified {
-			return false, nil
+
+		// Reject anything that is not a well-formed compact signature in the
+		// compressed-key recovery range. This mirrors wif.ValidateCompactSignature
+		// without the package cycle of importing wif here.
+		if _, err := wif.ValidateCompactSignature(sig); err != nil {
+			return false, errors.Wrapf(errInvalidSignature, "signature %d: %v", i, err)
+		}
+
+		// Recover the public key that produced this signature over the digest.
+		recovered, wasCompressed, err := ecdsa.RecoverCompact(sig, digest)
+		if err != nil {
+			return false, errors.Wrapf(errInvalidSignature, "signature %d recovery failed: %v", i, err)
+		}
+		if !wasCompressed {
+			return false, errors.Wrapf(errInvalidSignature, "signature %d was not compressed", i)
+		}
+
+		// Constant-time-independent byte compare of the recovered compressed
+		// key against the expected signer's compressed key.
+		if !bytes.Equal(recovered.SerializeCompressed(), pubKeys[i].Raw.SerializeCompressed()) {
+			return false, errors.Wrapf(errInvalidSignature, "signature %d was not produced by pubkey %d", i, i)
 		}
 	}
 	return true, nil

--- a/transaction/signed_transaction_test.go
+++ b/transaction/signed_transaction_test.go
@@ -96,3 +96,110 @@ func TestTransaction_SignAndVerify(t *testing.T) {
 		t.Error("verification failed")
 	}
 }
+
+// TestTransaction_VerifyNegativeCases pins the security-critical behaviour
+// that Verify must be fail-closed. Before the fix, Verify iterated over an
+// empty slice and returned (true, nil) for any input, including tampered
+// transactions, empty signature lists, and wrong keys.
+func TestTransaction_VerifyNegativeCases(t *testing.T) {
+	tx.Signatures = nil
+	defer func() {
+		tx.Signatures = nil
+	}()
+
+	stx := NewSignedTransaction(tx)
+	if err := stx.Sign(privateKeys, SteemChain); err != nil {
+		t.Fatalf("Sign failed: %v", err)
+	}
+	goodSigs := append([]string{}, tx.Signatures...)
+
+	const origWeight = 10000
+
+	// reSign returns the transaction to a clean, freshly-signed baseline.
+	reSign := func() {
+		tx.Signatures = nil
+		if err := stx.Sign(privateKeys, SteemChain); err != nil {
+			t.Fatalf("reSign failed: %v", err)
+		}
+	}
+
+	// Case 1: tampered transaction — mutating the signed payload after signing
+	// changes the digest, so recovery must produce a different key.
+	t.Run("tampered_digest", func(t *testing.T) {
+		tx.Signatures = goodSigs
+		defer reSign()
+
+		tx.PushOperation(&protocol.VoteOperation{
+			Voter:    "xeroc",
+			Author:   "xeroc",
+			Permlink: "piston",
+			Weight:   origWeight + 1, // mutate signed payload
+		})
+
+		ok, err := stx.Verify(publicKeys, SteemChain)
+		if ok {
+			t.Errorf("Verify returned true for a tampered transaction (err=%v)", err)
+		}
+		if err == nil {
+			t.Errorf("Verify returned nil error for a tampered transaction")
+		}
+	})
+
+	// Case 2: empty signature list must be fail-closed.
+	t.Run("empty_signatures", func(t *testing.T) {
+		tx.Signatures = nil
+		defer reSign()
+
+		ok, err := stx.Verify(publicKeys, SteemChain)
+		if ok {
+			t.Errorf("Verify returned true with no signatures (err=%v)", err)
+		}
+		if err == nil {
+			t.Errorf("Verify returned nil error with no signatures")
+		}
+	})
+
+	// Case 3: a signature that does not correspond to the supplied pubKey.
+	t.Run("wrong_pubkey", func(t *testing.T) {
+		tx.Signatures = goodSigs
+		defer reSign()
+
+		// An unrelated valid Steem public key (standard test vector).
+		wrongKey := &wif.PublicKey{}
+		if err := wrongKey.FromStr("STM8m5UgaFAAYQRuaNejYdS8FVLVp9Ss3K1qAVk5de6F8s3HnVbvA"); err != nil {
+			t.Fatalf("failed to parse wrong pubkey: %v", err)
+		}
+
+		ok, err := stx.Verify([]*wif.PublicKey{wrongKey}, SteemChain)
+		if ok {
+			t.Errorf("Verify returned true against an unrelated pubkey (err=%v)", err)
+		}
+		if err == nil {
+			t.Errorf("Verify returned nil error against an unrelated pubkey")
+		}
+	})
+
+	// Case 4: garbage signature bytes must not pass.
+	t.Run("malformed_signature", func(t *testing.T) {
+		tx.Signatures = []string{"deadbeef"}
+		defer reSign()
+
+		ok, err := stx.Verify(publicKeys, SteemChain)
+		if ok {
+			t.Errorf("Verify returned true for a malformed signature (err=%v)", err)
+		}
+		if err == nil {
+			t.Errorf("Verify returned nil error for a malformed signature")
+		}
+	})
+
+	// Sanity: the baseline verifies, proving the negatives above are about the
+	// inputs, not a broken fixture.
+	t.Run("baseline_still_verifies", func(t *testing.T) {
+		reSign()
+		ok, err := stx.Verify(publicKeys, SteemChain)
+		if err != nil || !ok {
+			t.Fatalf("baseline should verify, got ok=%v err=%v", ok, err)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Fixes the **[中] signature verification bypass** finding in `steem-audit/projects/steemutil/audit-reports/2026-07-code-scan.md`.

`SignedTransaction.Verify` built an empty slice and iterated over *that* instead of `tx.Signatures`, so the loop body never ran and the method returned `(true, nil)` for any input — no signatures, garbage signatures, signatures over a tampered digest, all passed.

## Fix

Rewrite as **recover-and-compare**: recover each signer's pubkey from the compact signature via `ecdsa.RecoverCompact` and compare to the expected key. This is the same verified mechanism already used in `wif.PublicKey.VerifySha256`.

> Note: the audit report's suggested patch used `ecdsa.ParseSignature(sig).Verify(...)`. That cannot work here — `Sign()` emits **compact/recoverable** signatures (`ecdsa.SignCompact`), while `ParseSignature` only parses **DER**. Even with correct iteration the report's patch would always fail. Recover-and-compare is the only correct approach.

Verify is now **fail-closed**: empty sigs, count mismatch, malformed hex, bad compact format, recovery failure, key mismatch → `(false, error)`.

## Test

- Existing `TestTransaction_SignAndVerify` still passes (positive path).
- New `TestTransaction_VerifyNegativeCases`: tampered digest, empty signatures, wrong pubkey, malformed signature (all return `false`), plus a baseline sanity check.

```
go test ./...   # all green
go vet ./...    # clean
```

Refs: steem-audit/projects/steemutil/audit-reports/2026-07-code-scan.md