### PR TITLE
fix(auth): rewrite memo encryption to spec, interop with steem-js

### DIFF
--- a/auth/memo.go
+++ b/auth/memo.go
@@ -1,155 +1,159 @@
 package auth
 
 import (
+	"bytes"
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
 	"crypto/sha256"
+	"crypto/sha512"
+	"encoding/binary"
 	"io"
+	"time"
 
 	"github.com/btcsuite/btcd/btcutil/base58"
+	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 	"github.com/pkg/errors"
+	"github.com/steemit/steemutil/encoder"
 	"github.com/steemit/steemutil/wif"
 )
 
-// EncryptedMemo represents an encrypted memo structure.
+// EncryptedMemo represents an encrypted memo, serialized to the canonical
+// Steem wire format (compatible with steem-js / steemd).
+//
+// Layout (all little-endian):
+//
+//	from     33 bytes  compressed secp256k1 public key of the sender
+//	to       33 bytes  compressed secp256k1 public key of the recipient
+//	nonce     8 bytes  uint64 nonce (little-endian)
+//	check     4 bytes  uint32 checksum (little-endian)
+//	n         varint   byte length of the ciphertext
+//	cipher    n bytes  AES-256-CBC ciphertext
 type EncryptedMemo struct {
-	From      string `json:"from"`
-	To        string `json:"to"`
-	Nonce     []byte `json:"nonce"`
-	Check     []byte `json:"check"`
-	Encrypted []byte `json:"encrypted"`
+	From      *wif.PublicKey
+	To        *wif.PublicKey
+	Nonce     uint64
+	Check     uint32
+	Encrypted []byte
 }
 
+// nonceLen is the fixed length of the on-wire nonce (uint64, little-endian).
+const nonceLen = 8
+
 // Encode encrypts a memo if it starts with '#', otherwise returns it as-is.
-// privateKey can be a WIF string or a PrivateKey object.
-// publicKey can be a public key string or a PublicKey object.
+// privateKey can be a WIF string or a *wif.PrivateKey.
+// publicKey can be a public key string (STM...) or a *wif.PublicKey.
+//
+// The encrypted output is byte-for-byte compatible with steem-js
+// memo.encode (next branch): ECDH shared secret, SHA-512 key derivation,
+// AES-256-CBC, and the canonical EncryptedMemo serialization.
 func Encode(privateKey interface{}, publicKey interface{}, memo string) (string, error) {
+	return EncodeWithNonce(privateKey, publicKey, memo, UniqueNonce())
+}
+
+// EncodeWithNonce is like Encode but with a caller-supplied nonce. It exists
+// primarily for deterministic tests; production callers should use Encode.
+func EncodeWithNonce(privateKey interface{}, publicKey interface{}, memo string, nonce uint64) (string, error) {
 	if memo == "" {
 		return "", errors.New("memo is required")
 	}
 
-	// If memo doesn't start with '#', return as-is
-	if len(memo) == 0 || memo[0] != '#' {
+	// Plain memos (no '#' prefix) pass through unmodified.
+	if memo[0] != '#' {
 		return memo, nil
 	}
+	plain := memo[1:]
 
-	// Remove '#' prefix
-	memo = memo[1:]
-
-	// Convert private key to PrivateKey object
 	privKey, err := toPrivateKey(privateKey)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to convert private key")
 	}
-
-	// Convert public key to PublicKey object
 	pubKey, err := toPublicKey(publicKey)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to convert public key")
 	}
 
-	// Get sender's public key
+	// Sender's own public key.
 	senderPubKey := &wif.PublicKey{}
 	if err := senderPubKey.FromStr(privKey.ToPubKeyStr()); err != nil {
-		return "", errors.Wrap(err, "failed to get sender public key")
+		return "", errors.Wrap(err, "failed to derive sender public key")
 	}
 
-	// Determine recipient public key
-	recipientPubKey := pubKey
-	if senderPubKey.ToStr() == pubKey.ToStr() {
-		// If sender and recipient are the same, we need the other key
-		// This is a simplified version - in practice, you'd need the actual recipient key
-		recipientPubKey = pubKey
-	}
-
-	// Encrypt the memo
-	encrypted, nonce, checksum, err := encryptMemo(privKey, recipientPubKey, []byte(memo))
+	encrypted, checksum, err := encryptMemo(privKey, pubKey, []byte(plain), nonce)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to encrypt memo")
 	}
 
-	// Create encrypted memo structure
 	encMemo := EncryptedMemo{
-		From:      senderPubKey.ToStr(),
-		To:        recipientPubKey.ToStr(),
+		From:      senderPubKey,
+		To:        pubKey,
 		Nonce:     nonce,
 		Check:     checksum,
 		Encrypted: encrypted,
 	}
 
-	// Serialize (simplified - in practice, you'd use the proper serializer)
-	// For now, we'll use a simple base64 encoding
 	memoBytes, err := serializeEncryptedMemo(encMemo)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to serialize encrypted memo")
 	}
 
-	// Encode to base58
-	encoded := base58.Encode(memoBytes)
-	return "#" + encoded, nil
+	return "#" + base58.Encode(memoBytes), nil
 }
 
 // Decode decrypts a memo if it starts with '#', otherwise returns it as-is.
+// privateKey can be a WIF string or a *wif.PrivateKey.
+//
+// The decryption is symmetric with Encode and interoperates with memos
+// produced by steem-js memo.encode: given a memo encrypted by A for B, B (and
+// only B) can recover the plaintext.
 func Decode(privateKey interface{}, memo string) (string, error) {
 	if memo == "" {
 		return "", errors.New("memo is required")
 	}
-
-	// If memo doesn't start with '#', return as-is
-	if len(memo) == 0 || memo[0] != '#' {
+	if memo[0] != '#' {
 		return memo, nil
 	}
 
-	// Remove '#' prefix
-	memo = memo[1:]
-
-	// Convert private key to PrivateKey object
 	privKey, err := toPrivateKey(privateKey)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to convert private key")
 	}
 
-	// Decode from base58
-	memoBytes := base58.Decode(memo)
+	memoBytes := base58.Decode(memo[1:])
 
-	// Deserialize encrypted memo
 	encMemo, err := deserializeEncryptedMemo(memoBytes)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to deserialize encrypted memo")
 	}
 
-	// Get sender's public key
+	// Identify the other party's public key. We are either the sender (our
+	// pubkey == From) or the recipient (our pubkey == To).
 	senderPubKey := &wif.PublicKey{}
 	if err := senderPubKey.FromStr(privKey.ToPubKeyStr()); err != nil {
-		return "", errors.Wrap(err, "failed to get sender public key")
+		return "", errors.Wrap(err, "failed to derive our public key")
 	}
 
-	// Determine the other party's public key
 	var otherPubKey *wif.PublicKey
-	if senderPubKey.ToStr() == encMemo.From {
-		otherPubKey = &wif.PublicKey{}
-		if err := otherPubKey.FromStr(encMemo.To); err != nil {
-			return "", errors.Wrap(err, "failed to parse recipient public key")
-		}
-	} else {
-		otherPubKey = &wif.PublicKey{}
-		if err := otherPubKey.FromStr(encMemo.From); err != nil {
-			return "", errors.Wrap(err, "failed to parse sender public key")
-		}
+	switch {
+	case senderPubKey.ToStr() == encMemo.From.ToStr():
+		otherPubKey = encMemo.To
+	case senderPubKey.ToStr() == encMemo.To.ToStr():
+		otherPubKey = encMemo.From
+	default:
+		return "", errors.New("memo was not encrypted for this key")
 	}
 
-	// Decrypt the memo
-	decrypted, err := decryptMemo(privKey, otherPubKey, encMemo.Nonce, encMemo.Encrypted, encMemo.Check)
+	plain, err := decryptMemo(privKey, otherPubKey, encMemo.Nonce, encMemo.Encrypted, encMemo.Check)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to decrypt memo")
 	}
 
-	// Return with '#' prefix
-	return "#" + string(decrypted), nil
+	return "#" + string(plain), nil
 }
 
-// Helper functions
+// ----------------------------------------------------------------------------
+// key conversion helpers
+// ----------------------------------------------------------------------------
 
 func toPrivateKey(key interface{}) (*wif.PrivateKey, error) {
 	switch v := key.(type) {
@@ -181,93 +185,123 @@ func toPublicKey(key interface{}) (*wif.PublicKey, error) {
 	}
 }
 
-// encryptMemo encrypts a memo using AES-256-CBC with shared secret derived from ECDH.
-func encryptMemo(privKey *wif.PrivateKey, pubKey *wif.PublicKey, message []byte) ([]byte, []byte, []byte, error) {
-	// Generate shared secret using ECDH
-	sharedSecret := deriveSharedSecret(privKey, pubKey)
+// ----------------------------------------------------------------------------
+// cryptography (Steem memo spec, matches steem-js)
+// ----------------------------------------------------------------------------
 
-	// Generate random nonce
-	nonce := make([]byte, 16)
-	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
-		return nil, nil, nil, err
-	}
-
-	// Create AES cipher
-	block, err := aes.NewCipher(sharedSecret[:32])
-	if err != nil {
-		return nil, nil, nil, err
-	}
-
-	// Use CBC mode
-	iv := nonce
-	mode := cipher.NewCBCEncrypter(block, iv)
-
-	// Pad message
-	padded := pkcs7Pad(message, aes.BlockSize)
-
-	// Encrypt
-	encrypted := make([]byte, len(padded))
-	mode.CryptBlocks(encrypted, padded)
-
-	// Calculate checksum (first 4 bytes of SHA256 of encrypted data)
-	hash := sha256.Sum256(encrypted)
-	checksum := hash[:4]
-
-	return encrypted, nonce, checksum, nil
+// sharedSecret computes the ECDH shared secret S = SHA-512(x), where x is the
+// 32-byte X coordinate of privKey * pubKey on secp256k1. This is symmetric:
+// SHA-512(privA * pubB) == SHA-512(privB * pubA).
+//
+// wif.PrivateKey.Raw.PrivKey is *btcec.PrivateKey, which is a type alias for
+// *secp256k1.PrivateKey (btcec/v2 re-exports decred's secp256k1/v4), so it can
+// be passed to GenerateSharedSecret with no conversion.
+func sharedSecret(privKey *wif.PrivateKey, pubKey *wif.PublicKey) []byte {
+	x := secp256k1.GenerateSharedSecret(privKey.Raw.PrivKey, pubKey.Raw)
+	s := sha512.Sum512(x)
+	return s[:] // 64 bytes
 }
 
-// decryptMemo decrypts a memo using AES-256-CBC.
-func decryptMemo(privKey *wif.PrivateKey, pubKey *wif.PublicKey, nonce, encrypted, checksum []byte) ([]byte, error) {
-	// Verify checksum
-	hash := sha256.Sum256(encrypted)
-	if len(checksum) < 4 {
-		return nil, errors.New("invalid checksum length")
-	}
-	for i := 0; i < 4; i++ {
-		if hash[i] != checksum[i] {
-			return nil, errors.New("checksum mismatch")
-		}
+// deriveEncryptionKey derives the 64-byte encryption key material:
+//
+//	ek = SHA-512( uint64_le(nonce) || S )
+//
+// The first 32 bytes are the AES-256 key; bytes [32:48] are the AES-CBC IV;
+// the checksum is derived separately (see encryptMemo).
+func deriveEncryptionKey(privKey *wif.PrivateKey, pubKey *wif.PublicKey, nonce uint64) []byte {
+	s := sharedSecret(privKey, pubKey)
+	var nonceBuf [nonceLen]byte
+	binary.LittleEndian.PutUint64(nonceBuf[:], nonce)
+	h := sha512.New()
+	h.Write(nonceBuf[:])
+	h.Write(s)
+	return h.Sum(nil) // 64 bytes
+}
+
+// checksumOf returns the 4-byte little-endian checksum = SHA-256(ek)[0:4]
+// reinterpreted as a uint32 (matching steem-js Aes.encrypt).
+func checksumOf(ek []byte) uint32 {
+	sum := sha256.Sum256(ek)
+	return binary.LittleEndian.Uint32(sum[0:4])
+}
+
+// encryptMemo encrypts message for pubKey under a fresh key derived from the
+// ECDH shared secret and nonce. Returns (ciphertext, checksum).
+func encryptMemo(privKey *wif.PrivateKey, pubKey *wif.PublicKey, message []byte, nonce uint64) ([]byte, uint32, error) {
+	ek := deriveEncryptionKey(privKey, pubKey, nonce)
+	key := ek[0:32]
+	iv := ek[32:48]
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, 0, err
 	}
 
-	// Generate shared secret using ECDH
-	sharedSecret := deriveSharedSecret(privKey, pubKey)
+	// Steem prefixes the plaintext with a varint length (bytebuffer
+	// writeVString) before encryption.
+	prefixed := prefixVarString(message)
+	padded := pkcs7Pad(prefixed, aes.BlockSize)
 
-	// Create AES cipher
-	block, err := aes.NewCipher(sharedSecret[:32])
+	ciphertext := make([]byte, len(padded))
+	cipher.NewCBCEncrypter(block, iv).CryptBlocks(ciphertext, padded)
+
+	return ciphertext, checksumOf(ek), nil
+}
+
+// decryptMemo is the inverse of encryptMemo.
+func decryptMemo(privKey *wif.PrivateKey, pubKey *wif.PublicKey, nonce uint64, ciphertext []byte, checksum uint32) ([]byte, error) {
+	if len(ciphertext) == 0 || len(ciphertext)%aes.BlockSize != 0 {
+		return nil, errors.New("invalid ciphertext length")
+	}
+
+	ek := deriveEncryptionKey(privKey, pubKey, nonce)
+	if checksumOf(ek) != checksum {
+		return nil, errors.New("checksum mismatch")
+	}
+
+	block, err := aes.NewCipher(ek[0:32])
 	if err != nil {
 		return nil, err
 	}
 
-	// Use CBC mode
-	iv := nonce
-	mode := cipher.NewCBCDecrypter(block, iv)
+	padded := make([]byte, len(ciphertext))
+	cipher.NewCBCDecrypter(block, ek[32:48]).CryptBlocks(padded, ciphertext)
 
-	// Decrypt
-	decrypted := make([]byte, len(encrypted))
-	mode.CryptBlocks(decrypted, encrypted)
-
-	// Remove padding
-	unpadded, err := pkcs7Unpad(decrypted)
+	plain, err := pkcs7Unpad(padded)
 	if err != nil {
 		return nil, err
 	}
 
-	return unpadded, nil
+	// Strip the varint length prefix that writeVString added at encrypt time.
+	return stripVarString(plain)
 }
 
-// deriveSharedSecret derives a shared secret using ECDH.
-func deriveSharedSecret(privKey *wif.PrivateKey, pubKey *wif.PublicKey) []byte {
-	// ECDH: shared secret = privKey * pubKey
-	// This is a simplified version - in practice, you'd use proper ECDH
-	// For now, we'll use a combination of both keys
-	privBytes := privKey.ToByte()
-	pubBytes := pubKey.ToByte()
-	combined := append(privBytes, pubBytes...)
-	hash := sha256.Sum256(combined)
-	return hash[:]
+// prefixVarString prepends an unsigned LEB128 varint encoding of len(b),
+// matching bytebuffer's writeVString (which uses unsigned writeVarint32).
+func prefixVarString(b []byte) []byte {
+	var buf [binary.MaxVarintLen64]byte
+	n := binary.PutUvarint(buf[:], uint64(len(b)))
+	out := make([]byte, n+len(b))
+	copy(out, buf[:n])
+	copy(out[n:], b)
+	return out
 }
 
-// pkcs7Pad adds PKCS7 padding to data.
+// stripVarString removes the leading unsigned varint length and returns the
+// bytes it described. It mirrors prefixVarString and tolerates only a
+// well-formed length that matches the remaining bytes.
+func stripVarString(b []byte) ([]byte, error) {
+	length, n := binary.Uvarint(b)
+	if n <= 0 {
+		return nil, errors.New("invalid varint length prefix")
+	}
+	if uint64(len(b)-n) != length {
+		return nil, errors.Errorf("varint length %d does not match payload %d", length, len(b)-n)
+	}
+	return b[n:], nil
+}
+
+// pkcs7Pad applies PKCS#7 padding so len(data) is a multiple of blockSize.
 func pkcs7Pad(data []byte, blockSize int) []byte {
 	padding := blockSize - len(data)%blockSize
 	padtext := make([]byte, padding)
@@ -277,13 +311,13 @@ func pkcs7Pad(data []byte, blockSize int) []byte {
 	return append(data, padtext...)
 }
 
-// pkcs7Unpad removes PKCS7 padding from data.
+// pkcs7Unpad validates and removes PKCS#7 padding.
 func pkcs7Unpad(data []byte) ([]byte, error) {
 	if len(data) == 0 {
 		return nil, errors.New("empty data")
 	}
 	padding := int(data[len(data)-1])
-	if padding > len(data) || padding == 0 {
+	if padding == 0 || padding > len(data) {
 		return nil, errors.New("invalid padding")
 	}
 	for i := len(data) - padding; i < len(data); i++ {
@@ -294,77 +328,106 @@ func pkcs7Unpad(data []byte) ([]byte, error) {
 	return data[:len(data)-padding], nil
 }
 
-// serializeEncryptedMemo serializes an encrypted memo (simplified version).
-func serializeEncryptedMemo(memo EncryptedMemo) ([]byte, error) {
-	// This is a simplified serialization
-	// In practice, you'd use the proper Steem serializer
-	// For now, we'll use a simple format: from|to|nonce|check|encrypted
-	fromBytes := []byte(memo.From)
-	toBytes := []byte(memo.To)
+// ----------------------------------------------------------------------------
+// nonce
+// ----------------------------------------------------------------------------
 
-	result := make([]byte, 0, len(fromBytes)+len(toBytes)+len(memo.Nonce)+len(memo.Check)+len(memo.Encrypted)+20)
-	result = append(result, byte(len(fromBytes)))
-	result = append(result, fromBytes...)
-	result = append(result, byte(len(toBytes)))
-	result = append(result, toBytes...)
-	result = append(result, byte(len(memo.Nonce)))
-	result = append(result, memo.Nonce...)
-	result = append(result, byte(len(memo.Check)))
-	result = append(result, memo.Check...)
-	result = append(result, memo.Encrypted...)
-	return result, nil
+// UniqueNonce returns a 64-bit nonce composed of the high 32 bits of the
+// current time in milliseconds and 32 random bits, matching steem-js
+// Aes.uniqueNonce() (next branch, PR #531).
+func UniqueNonce() uint64 {
+	now := uint64(time.Now().UnixMilli()) // low 32 bits kept via shift below
+	var randBuf [4]byte
+	if _, err := io.ReadFull(rand.Reader, randBuf[:]); err != nil {
+		// rand.Reader should never fail; fall back to time entropy if it does.
+		now ^= uint64(time.Now().UnixNano())
+		return now
+	}
+	random := uint64(randBuf[0])<<24 | uint64(randBuf[1])<<16 | uint64(randBuf[2])<<8 | uint64(randBuf[3])
+	return (now << 32) | random
 }
 
-// deserializeEncryptedMemo deserializes an encrypted memo (simplified version).
+// ----------------------------------------------------------------------------
+// wire format (de)serialization
+// ----------------------------------------------------------------------------
+
+// pubKeyLen is the length of a compressed secp256k1 public key.
+const pubKeyLen = 33
+
+func serializeEncryptedMemo(m EncryptedMemo) ([]byte, error) {
+	if m.From == nil || m.To == nil {
+		return nil, errors.New("encrypted memo missing from/to public keys")
+	}
+	var buf bytes.Buffer
+	enc := encoder.NewEncoder(&buf)
+
+	// from / to: raw 33-byte compressed public keys
+	if err := enc.WriteBytes(m.From.ToByte()); err != nil {
+		return nil, err
+	}
+	if err := enc.WriteBytes(m.To.ToByte()); err != nil {
+		return nil, err
+	}
+	// nonce: uint64 little-endian
+	if err := enc.EncodeNumber(m.Nonce); err != nil {
+		return nil, err
+	}
+	// check: uint32 little-endian
+	if err := enc.EncodeNumber(m.Check); err != nil {
+		return nil, err
+	}
+	// ciphertext length: unsigned varint (varint32 in steem-js)
+	if err := enc.EncodeUVarint(uint64(len(m.Encrypted))); err != nil {
+		return nil, err
+	}
+	if err := enc.WriteBytes(m.Encrypted); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
 func deserializeEncryptedMemo(data []byte) (EncryptedMemo, error) {
-	// This is a simplified deserialization
-	// In practice, you'd use the proper Steem deserializer
-	if len(data) < 5 {
-		return EncryptedMemo{}, errors.New("data too short")
+	var m EncryptedMemo
+
+	// Minimum: two public keys (33+33) + nonce(8) + check(4) + at least one
+	// varint byte. Reject short / malformed input early.
+	const minLen = pubKeyLen*2 + nonceLen + 4 + 1
+	if len(data) < minLen {
+		return m, errors.Errorf("encrypted memo too short: %d bytes", len(data))
 	}
 
-	offset := 0
-	fromLen := int(data[offset])
-	offset++
-	if offset+fromLen > len(data) {
-		return EncryptedMemo{}, errors.New("invalid from length")
+	off := 0
+	read := func(n int) []byte {
+		b := data[off : off+n]
+		off += n
+		return b
 	}
-	from := string(data[offset : offset+fromLen])
-	offset += fromLen
 
-	toLen := int(data[offset])
-	offset++
-	if offset+toLen > len(data) {
-		return EncryptedMemo{}, errors.New("invalid to length")
+	fromBytes := read(pubKeyLen)
+	toBytes := read(pubKeyLen)
+
+	m.From = &wif.PublicKey{}
+	if err := m.From.FromByte(fromBytes); err != nil {
+		return m, errors.Wrap(err, "failed to parse 'from' public key")
 	}
-	to := string(data[offset : offset+toLen])
-	offset += toLen
-
-	nonceLen := int(data[offset])
-	offset++
-	if offset+nonceLen > len(data) {
-		return EncryptedMemo{}, errors.New("invalid nonce length")
+	m.To = &wif.PublicKey{}
+	if err := m.To.FromByte(toBytes); err != nil {
+		return m, errors.Wrap(err, "failed to parse 'to' public key")
 	}
-	nonce := make([]byte, nonceLen)
-	copy(nonce, data[offset:offset+nonceLen])
-	offset += nonceLen
 
-	checkLen := int(data[offset])
-	offset++
-	if offset+checkLen > len(data) {
-		return EncryptedMemo{}, errors.New("invalid check length")
+	m.Nonce = binary.LittleEndian.Uint64(read(nonceLen))
+	m.Check = binary.LittleEndian.Uint32(read(4))
+
+	length, n := binary.Uvarint(data[off:])
+	if n <= 0 {
+		return m, errors.New("invalid ciphertext length varint")
 	}
-	check := make([]byte, checkLen)
-	copy(check, data[offset:offset+checkLen])
-	offset += checkLen
+	off += n
 
-	encrypted := data[offset:]
-
-	return EncryptedMemo{
-		From:      from,
-		To:        to,
-		Nonce:     nonce,
-		Check:     check,
-		Encrypted: encrypted,
-	}, nil
+	if uint64(len(data)-off) != length {
+		return m, errors.Errorf("ciphertext length %d does not match remaining %d bytes", length, len(data)-off)
+	}
+	m.Encrypted = make([]byte, len(data)-off)
+	copy(m.Encrypted, data[off:])
+	return m, nil
 }

--- a/auth/memo_test.go
+++ b/auth/memo_test.go
@@ -1,20 +1,55 @@
 package auth
 
 import (
+	"encoding/hex"
+	"strings"
 	"testing"
 
 	"github.com/steemit/steemutil/wif"
 )
 
+// ----------------------------------------------------------------------------
+// steem-js interop vectors
+//
+// Generated from steem-js `next` @ d3945f1 (src/memo + src/auth/ecc/src/aes),
+// the post-#524/#525/#530/#531 security-audited state. These pin byte-for-byte
+// compatibility with the canonical Steem memo format.
+//
+// Recipient key is derived from a fixed seed — TEST ONLY, do not use on mainnet.
+// ----------------------------------------------------------------------------
+
+const (
+	// senderWif is the historical steemutil test WIF; its public key is senderPub.
+	senderWif = "5JRaypasxMx1L97ZUX7YuC5Psb5EAbF821kkAGtBj7xCJFQcbLg"
+	senderPub = "STM6aGPtxMUGnTPfKLSxdwCHbximSJxzrRjeQmwRW9BRCdrFotKLs"
+
+	// recipientWif / recipientPub come from PrivateKey.fromBuffer(seed) where
+	// seed = 0123456789abcdef... (32 bytes).
+	recipientWif = "5HpneLQNKrcznVCQpzodYwAmZ4AoHeyjuRf9iAHAa498rP5kuWb"
+	recipientPub = "STM7NBdzdQjZi7M6xo7XqcwcW4YCBLZeqjBvpj6obDpiXhbTSnhjq"
+
+	// interopVectorNonce is the fixed 64-bit nonce used to generate the vector.
+	interopVectorNonce uint64 = 14653678900875387904
+
+	// interopVectorMemo is the plaintext WITHOUT the leading '#'.
+	interopVectorMemo = "hello steem"
+
+	// interopVectorEnc is the exact output of steem-js memo.encode(senderWif,
+	// recipientPub, "#hello steem", "14653678900875387904").
+	interopVectorEnc = "#Dyn1R3F3BGrJgACeq3pw3foykzH18UqUTdx1hZ7PxyXGNogQ37vr2WhzXpAY2VgM7iRqShkhAcSjnpVW2Gbpc5pXnt8GjnL3mU6jyXngtz8ekbpmdQGuBtXmKAgoCEdj1"
+
+	// interopVectorWireHex is the base58-decoded wire bytes of interopVectorEnc.
+	interopVectorWireHex = "02de0381af8fa527ceee901e2463aa15132a69b96368782a1bced60065fc271b1a034646ae5047316b4230d0086c8acec687f00b1cd9d1dc634f6cb358ac0a9a8fff0064506352535ccb8e061c0610a08212a29f599d0ce16ace3086da554c"
+)
+
+// TestEncodeDecodePlainText: plain memos pass through untouched both ways.
 func TestEncodeDecodePlainText(t *testing.T) {
-	// Plain text should be returned as-is
 	memo := "plain text memo"
-	
+
 	encoded, err := Encode(nil, nil, memo)
 	if err != nil {
 		t.Fatalf("Encode failed: %v", err)
 	}
-
 	if encoded != memo {
 		t.Errorf("Encode should return plain text as-is, got: %s", encoded)
 	}
@@ -23,92 +58,296 @@ func TestEncodeDecodePlainText(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Decode failed: %v", err)
 	}
-
 	if decoded != memo {
 		t.Errorf("Decode should return plain text as-is, got: %s", decoded)
 	}
 }
 
-func TestEncodeDecodeWithHashPrefix(t *testing.T) {
-	// Create test keys
-	senderWif := "5JRaypasxMx1L97ZUX7YuC5Psb5EAbF821kkAGtBj7xCJFQcbLg"
-	recipientPubKey := "STM8m5UgaFAAYQRuaNejYdS8FVLVp9Ss3K1qAVk5de6F8s3HnVbvA"
-
-	memo := "#test memo"
-
-	// Encode
-	encoded, err := Encode(senderWif, recipientPubKey, memo)
-	if err != nil {
-		t.Fatalf("Encode failed: %v", err)
-	}
-
-	if encoded == memo {
-		t.Error("Encode should encrypt memo with # prefix")
-	}
-
-	if len(encoded) == 0 {
-		t.Error("Encode returned empty string")
-	}
-
-	// Decode
-	decoded, err := Decode(senderWif, encoded)
-	if err != nil {
-		t.Fatalf("Decode failed: %v", err)
-	}
-
-	if decoded != memo {
-		t.Errorf("Decode failed: expected %s, got %s", memo, decoded)
-	}
-}
-
-func TestEncodeDecodeWithPrivateKeyObject(t *testing.T) {
-	// Test with PrivateKey object instead of WIF string
-	senderWif := "5JRaypasxMx1L97ZUX7YuC5Psb5EAbF821kkAGtBj7xCJFQcbLg"
-	recipientPubKey := "STM8m5UgaFAAYQRuaNejYdS8FVLVp9Ss3K1qAVk5de6F8s3HnVbvA"
-
-	senderPrivKey := &wif.PrivateKey{}
-	if err := senderPrivKey.FromWif(senderWif); err != nil {
-		t.Fatalf("Failed to create private key: %v", err)
-	}
-
-	recipientPubKeyObj := &wif.PublicKey{}
-	if err := recipientPubKeyObj.FromStr(recipientPubKey); err != nil {
-		t.Fatalf("Failed to create public key: %v", err)
-	}
-
-	memo := "#test memo with objects"
-
-	// Encode with objects
-	encoded, err := Encode(senderPrivKey, recipientPubKeyObj, memo)
-	if err != nil {
-		t.Fatalf("Encode failed: %v", err)
-	}
-
-	// Decode with WIF string (should work both ways)
-	decoded, err := Decode(senderWif, encoded)
-	if err != nil {
-		t.Fatalf("Decode failed: %v", err)
-	}
-
-	if decoded != memo {
-		t.Errorf("Decode failed: expected %s, got %s", memo, decoded)
-	}
-}
-
+// TestEncodeDecodeEmptyMemo: empty input is rejected.
 func TestEncodeDecodeEmptyMemo(t *testing.T) {
-	memo := ""
-	
-	encoded, err := Encode(nil, nil, memo)
-	if err == nil {
+	if _, err := Encode(nil, nil, ""); err == nil {
 		t.Error("Encode should fail for empty memo")
 	}
-
-	decoded, err := Decode(nil, memo)
-	if err == nil {
+	if _, err := Decode(nil, ""); err == nil {
 		t.Error("Decode should fail for empty memo")
 	}
-
-	_ = encoded
-	_ = decoded
 }
 
+// TestEncodeByteEqualityWithSteemJS pins the core interop guarantee: Go
+// EncodeWithNonce must produce the exact same ciphertext as steem-js
+// memo.encode for identical inputs. A single byte drift here means we have
+// broken wire-format compatibility.
+func TestEncodeByteEqualityWithSteemJS(t *testing.T) {
+	got, err := EncodeWithNonce(senderWif, recipientPub, "#"+interopVectorMemo, interopVectorNonce)
+	if err != nil {
+		t.Fatalf("EncodeWithNonce failed: %v", err)
+	}
+	if got != interopVectorEnc {
+		t.Fatalf("byte-equality with steem-js broken:\n got:  %s\n want: %s", got, interopVectorEnc)
+	}
+}
+
+// TestDecodeSteemJSMemo verifies our decoder can decrypt a memo produced by
+// steem-js (the wire is steem-js's, the key is the recipient's).
+func TestDecodeSteemJSMemo(t *testing.T) {
+	decoded, err := Decode(recipientWif, interopVectorEnc)
+	if err != nil {
+		t.Fatalf("Decode of steem-js memo failed: %v", err)
+	}
+	if decoded != "#"+interopVectorMemo {
+		t.Fatalf("unexpected plaintext: got %q, want %q", decoded, "#"+interopVectorMemo)
+	}
+}
+
+// TestCrossKeyEncryption is the regression test for the original [高] finding.
+//
+// The bug: deriveSharedSecret did SHA-256(privBytes || pubBytes), which is NOT
+// symmetric — sender's key was SHA-256(privS||pubR) while the recipient's was
+// SHA-256(privR||pubS), so the recipient could never decrypt. The old tests
+// passed only because they used the SAME WIF for encrypt and decrypt
+// (self-to-self), hiding the asymmetry.
+//
+// This test uses two DIFFERENT keys: sender encrypts, recipient decrypts. It
+// must succeed now (real ECDH is symmetric) and would fail against the old code.
+func TestCrossKeyEncryption(t *testing.T) {
+	const plaintext = "#secret message between two parties"
+
+	// Sender encrypts to the recipient's public key.
+	enc, err := EncodeWithNonce(senderWif, recipientPub, plaintext, interopVectorNonce)
+	if err != nil {
+		t.Fatalf("Encode (sender) failed: %v", err)
+	}
+	if enc == plaintext {
+		t.Fatal("memo was not encrypted")
+	}
+
+	// Recipient decrypts with its own private key.
+	dec, err := Decode(recipientWif, enc)
+	if err != nil {
+		t.Fatalf("Decode (recipient) failed: %v — this is exactly the original bug", err)
+	}
+	if dec != plaintext {
+		t.Fatalf("cross-key decryption mismatch: got %q, want %q", dec, plaintext)
+	}
+
+	// Symmetry the other way: recipient encrypts to sender, sender decrypts.
+	enc2, err := EncodeWithNonce(recipientWif, senderPub, plaintext, interopVectorNonce)
+	if err != nil {
+		t.Fatalf("Encode (recipient) failed: %v", err)
+	}
+	dec2, err := Decode(senderWif, enc2)
+	if err != nil {
+		t.Fatalf("Decode (sender) failed: %v", err)
+	}
+	if dec2 != plaintext {
+		t.Fatalf("reverse cross-key decryption mismatch: got %q, want %q", dec2, plaintext)
+	}
+}
+
+// TestEncodeAcceptsKeyObjects verifies the interface{} entry points accept
+// *wif.PrivateKey / *wif.PublicKey as well as strings.
+func TestEncodeAcceptsKeyObjects(t *testing.T) {
+	priv, err := toPrivateKey(senderWif)
+	if err != nil {
+		t.Fatalf("toPrivateKey: %v", err)
+	}
+	pub, err := toPublicKey(recipientPub)
+	if err != nil {
+		t.Fatalf("toPublicKey: %v", err)
+	}
+
+	enc, err := EncodeWithNonce(priv, pub, "#obj test", interopVectorNonce)
+	if err != nil {
+		t.Fatalf("EncodeWithNonce objects: %v", err)
+	}
+	// Same inputs as strings must yield the same ciphertext.
+	encStr, err := EncodeWithNonce(senderWif, recipientPub, "#obj test", interopVectorNonce)
+	if err != nil {
+		t.Fatalf("EncodeWithNonce strings: %v", err)
+	}
+	if enc != encStr {
+		t.Errorf("object vs string inputs diverged:\n obj: %s\n str: %s", enc, encStr)
+	}
+}
+
+// TestDecodeRejectsWrongKey: a third party (neither sender nor recipient)
+// cannot decrypt the memo — Decode must report it was not encrypted for them.
+func TestDecodeRejectsWrongKey(t *testing.T) {
+	// A completely unrelated key.
+	const strangerWif = "5KQwrPbwdL6PhXujxW37FSSQZ1JiwsST4cqQzDeyXtP79zkvFD3"
+	if _, err := Decode(strangerWif, interopVectorEnc); err == nil {
+		t.Fatal("Decode with an unrelated key should fail, but succeeded")
+	}
+}
+
+// TestDecodeRejectsTamperedMemo: flipping any byte of the ciphertext must
+// produce a checksum/padding failure, not a silently wrong plaintext.
+func TestDecodeRejectsTamperedMemo(t *testing.T) {
+	enc, err := EncodeWithNonce(senderWif, recipientPub, "#tamper me", interopVectorNonce)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	// Flip the last data character of the base58 payload (not the '#').
+	tampered := enc[:len(enc)-1] + string(flipBase58Char(enc[len(enc)-1]))
+	if tampered == enc {
+		t.Skip("could not produce a differing tampered string")
+	}
+	if _, err := Decode(recipientWif, tampered); err == nil {
+		t.Fatal("Decode of a tampered memo should fail")
+	}
+}
+
+// TestRoundTripUniqueNonce verifies the default Encode path (random nonce)
+// still round-trips through Decode.
+func TestRoundTripUniqueNonce(t *testing.T) {
+	const plaintext = "#random nonce round trip"
+
+	enc, err := Encode(senderWif, recipientPub, plaintext)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	// Two calls with random nonces must (overwhelmingly likely) differ.
+	enc2, err := Encode(senderWif, recipientPub, plaintext)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	if enc == enc2 {
+		t.Error("expected distinct ciphertexts from random nonces, got identical")
+	}
+
+	dec, err := Decode(recipientWif, enc)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if dec != plaintext {
+		t.Fatalf("round-trip mismatch: got %q want %q", dec, plaintext)
+	}
+}
+
+// TestUniqueNonceMatchesSteemJSLayout sanity-checks that UniqueNonce packs the
+// time into the high 32 bits and randomness into the low 32 bits, matching
+// steem-js Aes.uniqueNonce(). (We assert structure, not an exact value.)
+func TestUniqueNonceMatchesSteemJSLayout(t *testing.T) {
+	hi := interopVectorNonce >> 32
+	_ = hi // vector's high bits are time-ish ms (non-zero), low bits random.
+
+	n := UniqueNonce()
+	if n>>32 == 0 {
+		t.Error("UniqueNonce high 32 bits are zero")
+	}
+	if n&0xffffffff == 0 {
+		t.Error("UniqueNonce low 32 bits are zero (no randomness)")
+	}
+}
+
+// TestWireFormatLayout decodes the steem-js vector by hand and asserts the
+// exact byte layout the Go serializer must reproduce:
+//
+//	from(33) || to(33) || nonce(uint64 LE) || check(uint32 LE) || varint(len) || ct
+func TestWireFormatLayout(t *testing.T) {
+	wire, err := hex.DecodeString(interopVectorWireHex)
+	if err != nil {
+		t.Fatalf("bad wire hex: %v", err)
+	}
+
+	const pubLen = 33
+	fromBytes := wire[0:pubLen]
+	toBytes := wire[pubLen : pubLen*2]
+	off := pubLen * 2
+
+	// nonce (uint64 LE)
+	var nonceBytes [8]byte
+	copy(nonceBytes[:], wire[off:off+8])
+	off += 8
+
+	// check (uint32 LE)
+	var checkBytes [4]byte
+	copy(checkBytes[:], wire[off:off+4])
+	off += 4
+
+	// varint length of ciphertext
+	length, n := varintDecode(wire[off:])
+	off += n
+
+	ciphertext := wire[off:]
+
+	// Cross-check each field against independently-known values.
+	fromPub := &wif.PublicKey{}
+	if err := fromPub.FromByte(fromBytes); err != nil {
+		t.Fatalf("parse from: %v", err)
+	}
+	if fromPub.ToStr() != senderPub {
+		t.Errorf("from pubkey: got %s, want %s", fromPub.ToStr(), senderPub)
+	}
+	toPub := &wif.PublicKey{}
+	if err := toPub.FromByte(toBytes); err != nil {
+		t.Fatalf("parse to: %v", err)
+	}
+	if toPub.ToStr() != recipientPub {
+		t.Errorf("to pubkey: got %s, want %s", toPub.ToStr(), recipientPub)
+	}
+	if fromBytes[0] != 0x02 && fromBytes[0] != 0x03 {
+		t.Errorf("from key prefix byte unexpected: 0x%02x", fromBytes[0])
+	}
+
+	// nonce little-endian must equal interopVectorNonce.
+	var nonceLE [8]byte
+	for i := 0; i < 8; i++ {
+		nonceLE[i] = byte(interopVectorNonce >> (8 * i))
+	}
+	if nonceBytes != nonceLE {
+		t.Errorf("nonce LE mismatch: got %x, want %x", nonceBytes, nonceLE)
+	}
+
+	// Re-serialize the parsed memo and require byte-for-byte equality, which
+	// simultaneously validates the varint length and the check field.
+	memo := EncryptedMemo{From: fromPub, To: toPub}
+	memo.Nonce = interopVectorNonce
+	memo.Check = leUint32(checkBytes)
+	memo.Encrypted = ciphertext
+	reserialized, err := serializeEncryptedMemo(memo)
+	if err != nil {
+		t.Fatalf("serialize: %v", err)
+	}
+	if hex.EncodeToString(reserialized) != interopVectorWireHex {
+		t.Errorf("reserialized wire differs from steem-js:\n got  %x\n want %s", reserialized, interopVectorWireHex)
+	}
+	if int(length) != len(ciphertext) {
+		t.Errorf("varint length %d != ciphertext len %d", length, len(ciphertext))
+	}
+}
+
+// flipBase58Char returns a different base58 character (for tamper tests).
+func flipBase58Char(c byte) byte {
+	const alphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+	idx := strings.IndexByte(alphabet, c)
+	if idx < 0 {
+		return 'z'
+	}
+	return alphabet[(idx+1)%len(alphabet)]
+}
+
+// varintDecode reads an unsigned LEB128 varint, returning value and byte count.
+func varintDecode(b []byte) (uint64, int) {
+	var x uint64
+	var s uint
+	for i, c := range b {
+		if i >= 10 {
+			return 0, 0
+		}
+		if c < 0x80 {
+			if i == 9 && c > 1 {
+				return 0, 0
+			}
+			return x | uint64(c)<<s, i + 1
+		}
+		x |= uint64(c&0x7f) << s
+		s += 7
+	}
+	return 0, 0
+}
+
+// leUint32 decodes a 4-byte little-endian uint32.
+func leUint32(b [4]byte) uint32 {
+	return uint32(b[0]) | uint32(b[1])<<8 | uint32(b[2])<<16 | uint32(b[3])<<24
+}


### PR DESCRIPTION
## Summary

Fixes the **[高] memo encryption** finding in `steem-audit/projects/steemutil/audit-reports/2026-07-code-scan.md`: `deriveSharedSecret` was `SHA-256(privBytes ‖ pubBytes)`, not ECDH — so it was **not symmetric**, and the real recipient could never decrypt a memo addressed to them. The old tests passed only because they used the same WIF for both encrypt and decrypt (self-to-self), hiding the bug.

The audit report said "just swap to real ECDH", but in fact **four layers** were wrong and had to be rewritten to reach interoperability: key derivation (SHA-512, not SHA-256), plaintext framing (writeVString varint prefix), checksum, and the entire wire format (steem-js canonical `EncryptedMemo` layout, not the previous custom 1-byte-length-prefixed format).

## Fix

Rewritten to the canonical algorithm, verified **byte-for-byte against steem-js** `next` @ `d3945f1` (`src/memo` + `src/auth/ecc/src/aes`):

```
x  = ECDH(priv, pub)          # secp256k1 shared X coordinate
S  = SHA512(x)                # 64 bytes
ek = SHA512(uint64_le(nonce) ‖ S)
key = ek[0:32];  iv = ek[32:48]
check = uint32_le(SHA256(ek)[0:4])
plaintext = varint32(len) ‖ utf8(message)   # bytebuffer writeVString
ciphertext = AES-256-CBC(key, iv, PKCS7(plaintext))

wire = from(33) ‖ to(33) ‖ nonce(uint64 LE) ‖ check(uint32 LE) ‖ varint32(len(ct)) ‖ ct
```

- ECDH via `secp256k1.GenerateSharedSecret` (decred `dcrec/secp256k1/v4`, already a dep). **No type conversion** needed: `btcec.PrivateKey` is a type alias for `secp256k1.PrivateKey`.
- Public `Encode`/`Decode` signatures **unchanged** (consumed by steemgosdk). Added `EncodeWithNonce` (deterministic tests) and `UniqueNonce` (mirrors steem-js `Aes.uniqueNonce`: `time<<32 ‖ random32`).

## Verification

Test vectors were generated by running steem-js locally with fixed `(senderWif, recipientPub, memo, nonce)`; the generator script was temporary and removed (steem-js tree left clean).

- `TestEncodeByteEqualityWithSteemJS` — Go `EncodeWithNonce` output is **identical** to steem-js `memo.encode` for the same inputs.
- `TestCrossKeyEncryption` — sender encrypts, **recipient** decrypts (the path the bug broke), both directions.
- `TestDecodeSteemJSMemo` — Go decodes a memo produced by steem-js.
- `TestDecodeRejectsWrongKey` / `TestDecodeRejectsTamperedMemo` — fail-closed.
- `TestWireFormatLayout` — hand-decodes the wire and re-serializes for byte equality.

```
go test ./...   # all green
go vet ./...    # clean
```

Refs: steem-audit/projects/steemutil/audit-reports/2026-07-code-scan.md